### PR TITLE
#125 Conflict akka_http 10.0.3

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/http/oauth/OAuth2Provider.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/oauth/OAuth2Provider.scala
@@ -5,13 +5,13 @@ import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 import akka.stream.Materializer
 import com.danielasfregola.twitter4s.entities.{AccessToken, ConsumerToken}
-import com.danielasfregola.twitter4s.util.Encoder
+import com.danielasfregola.twitter4s.util.{Encoder, UriHelpers}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random
 
-private[twitter4s] class OAuth2Provider(consumerToken: ConsumerToken, accessToken: AccessToken) extends Encoder {
+private[twitter4s] class OAuth2Provider(consumerToken: ConsumerToken, accessToken: AccessToken) extends Encoder with UriHelpers {
 
   def oauth2Header(implicit request: HttpRequest, materializer: Materializer): Future[HttpHeader] = {
     implicit val ec = materializer.executionContext

--- a/src/main/scala/com/danielasfregola/twitter4s/http/package.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/package.scala
@@ -2,8 +2,6 @@ package com.danielasfregola.twitter4s
 
 import java.net.URLEncoder
 
-import akka.http.scaladsl.model.Uri
-
 package object http {
 
   private val SpecialEncodings = Map("+" -> "%20", "." -> "%2E", "-" -> "%2D", "*" -> "%2A", "_" -> "%5F")
@@ -17,12 +15,6 @@ package object http {
     def escapeSpecialChars = SpecialEncodings.foldRight(urlEncoded) {
       case ((char, encoding), acc) => acc.replace(char, encoding)
     }
-
-  }
-
-  implicit class RichUri(val uri: Uri) extends AnyVal {
-
-    def endpoint = s"${uri.scheme}:${uri.authority}${uri.path}"
   }
 
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/util/UriHelpers.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/util/UriHelpers.scala
@@ -6,11 +6,10 @@ import akka.http.scaladsl.model.Uri.Query
 trait UriHelpers {
 
   implicit def toRichUri(uri: Uri): RichUri = new RichUri(uri)
-  implicit def toUri(richUri: RichUri): Uri = richUri.uri
 
   class RichUri(val uri: Uri) {
 
-    def endpoint: String = uri.withQuery(Query()).toString
+    val endpoint: String = uri.withQuery(Query()).toString
   }
 
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/util/UriHelpers.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/util/UriHelpers.scala
@@ -1,0 +1,16 @@
+package com.danielasfregola.twitter4s.util
+
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Query
+
+trait UriHelpers {
+
+  implicit def toRichUri(uri: Uri): RichUri = new RichUri(uri)
+  implicit def toUri(richUri: RichUri): Uri = richUri.uri
+
+  class RichUri(val uri: Uri) {
+
+    def endpoint: String = uri.withQuery(Query()).toString
+  }
+
+}

--- a/src/test/scala/com/danielasfregola/twitter4s/helpers/Spec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/helpers/Spec.scala
@@ -2,10 +2,11 @@ package com.danielasfregola.twitter4s.helpers
 
 import akka.http.scaladsl.model.{HttpCharsets, MediaTypes}
 import com.danielasfregola.twitter4s.entities.{AccessToken, ConsumerToken}
+import com.danielasfregola.twitter4s.util.UriHelpers
 import org.specs2.matcher.Scope
 import org.specs2.mutable.SpecificationLike
 
-trait Spec extends SpecificationLike {
+trait Spec extends SpecificationLike with UriHelpers {
 
   val `application/x-www-form-urlencoded` = MediaTypes.`application/x-www-form-urlencoded` withCharset HttpCharsets.`UTF-8`
 
@@ -15,5 +16,4 @@ trait Spec extends SpecificationLike {
     val accessToken = AccessToken("access-key", "access-secret")
 
   }
-
 }

--- a/src/test/scala/com/danielasfregola/twitter4s/util/UriHelpersSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/util/UriHelpersSpec.scala
@@ -1,0 +1,23 @@
+package com.danielasfregola.twitter4s.util
+
+import akka.http.scaladsl.model.Uri
+import org.specs2.mutable.Specification
+
+class UriHelpersSpec extends Specification with UriHelpers {
+
+  "UriHelpers" should {
+
+    "extract an endpoint representation" in {
+
+      "from a uri" in {
+        val uri = Uri("https://api.twitter.com/1.1/lists/members/create.json?param1=8044403&param2=daniela")
+        uri.endpoint === "https://api.twitter.com/1.1/lists/members/create.json"
+      }
+
+      "from a uri with explicit port" in {
+        val uri = Uri("http://example.com:8080/path?p=test")
+        uri.endpoint === "http://example.com:8080/path"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Apparently, the definition of Uri.Authority.toString() has changed and this is breaking the library when overriding the version of `akka-http` from 10.0.1 to 10.0.3 (or higher).

I have changed the definition of `endpoint`, used when generating authentication tokens, to a safer approach.