### PR TITLE
Parametter must be encoded twice for the signature

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/http/oauth/OAuth2Provider.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/oauth/OAuth2Provider.scala
@@ -83,7 +83,7 @@ private[twitter4s] class OAuth2Provider(consumerToken: ConsumerToken, accessToke
     }
   }
 
-  def queryParams(implicit request: HttpRequest) = request.uri.query().toMap
+  def queryParams(implicit request: HttpRequest) = request.uri.query().toMap.mapValues(_.toAscii)
 
   private def encodeParams(params: Map[String, String]) =
     params.keySet.toList.sorted


### PR DESCRIPTION
 The function searchTweet throws an error "Could not authenticate you code 32" when the query contains a space.

` val f = restClient.searchTweet(query="docker AND swarm",language = Some(Language.French)).map{
       data => data.data.statuses.foreach{
         t => println(t.text)
       }
     }
     Await.result(f,Duration.Inf)
`

The problem comes from the signature: the parameter must be encoded one time for the uri and one more time for the signature.  
> Make sure to percent encode the parameter string! The signature base string should contain exactly 2 ampersand ‘&’ characters. The percent ‘%’ characters in the parameter string should be encoded as %25 in the signature base string.

[Creating the signature base string](https://dev.twitter.com/oauth/overview/creating-signatures)

I hope my PR helps you and thank you for twitter4s and your job on it
 