### PR TITLE
do not encode the query before added to the query

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClient.scala
@@ -76,7 +76,7 @@ trait TwitterSearchClient {
                   max_id: Option[Long] = None,
                   callback: Option[String] = None): Future[RatedData[StatusSearch]] = {
     import restClient._
-    val parameters = TweetSearchParameters(query.escapeSpecialChars, count, include_entities, result_type, geocode, language, locale, until, since_id, max_id, callback)
+    val parameters = TweetSearchParameters(query, count, include_entities, result_type, geocode, language, locale, until, since_id, max_id, callback)
     Get(s"$searchUrl/tweets.json", parameters).respondAsRated[StatusSearch]
   }
 }


### PR DESCRIPTION
Hello
The function searchTweet, the parameter "query" was encoded twice in the uri: one with
escapeSpecialChars and one with the default "toString"
