### PR TITLE
Change tests to load all resources using UTF-8 character encoding

### DIFF
--- a/src/test/scala/com/danielasfregola/twitter4s/helpers/FixturesSupport.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/helpers/FixturesSupport.scala
@@ -3,11 +3,11 @@ package com.danielasfregola.twitter4s.helpers
 import com.danielasfregola.twitter4s.http.serializers.JsonSupport
 import org.json4s.native.Serialization
 
-import scala.io.Source
+import scala.io.{Codec, Source}
 
 trait FixturesSupport extends JsonSupport {
 
-  def load(resourcePath: String): String = Source.fromURL(getClass.getResource(resourcePath)).mkString
+  def load(resourcePath: String): String = Source.fromURL(getClass.getResource(resourcePath))(Codec.UTF8).mkString
   def loadJsonAs[T: Manifest](resourcePath: String): T = readJsonAs[T](load(resourcePath))
 
   def readJsonAs[T: Manifest](json: String): T = Serialization.read[T](json)

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/streaming/StreamingClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/streaming/StreamingClientSpec.scala
@@ -9,6 +9,8 @@ import com.danielasfregola.twitter4s.entities.streaming.user._
 import com.danielasfregola.twitter4s.entities.{DirectMessage, Tweet}
 import com.danielasfregola.twitter4s.helpers.{ClientSpec, TestActorSystem}
 
+import scala.io.Codec
+
 class StreamingClientSpec extends TestActorSystem with ClientSpec {
 
   abstract class ClientSpecContext extends StreamingClientSpecContext {
@@ -19,7 +21,7 @@ class StreamingClientSpec extends TestActorSystem with ClientSpec {
     def buildResponse(resourcePath: String): HttpResponse = {
       val contentType = ContentTypes.`application/json`
       val streamInput = getClass.getResourceAsStream(resourcePath)
-      val data = scala.io.Source.fromInputStream(streamInput).getLines.filter(_.nonEmpty)
+      val data = scala.io.Source.fromInputStream(streamInput)(Codec.UTF8).getLines.filter(_.nonEmpty)
       val chunks = data.map(d => HttpEntity.ChunkStreamPart(s"$d\r\n")).toList
       HttpResponse(entity = HttpEntity.Chunked(contentType, Source(chunks)))
     }


### PR DESCRIPTION
In order to make all tests pass even if the system's default character encoding is not UTF-8