### PR TITLE
Fix error when uploading media due to custom unmarshaller

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/media/TwitterMediaClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/media/TwitterMediaClient.scala
@@ -121,12 +121,11 @@ trait TwitterMediaClient {
     import restClient._
     val formData: FormData = FormData(
       Source(List(
-      FormData.BodyPart.Strict("command", "APPEND"),
-      FormData.BodyPart.Strict("media_id", mediaId.toString),
+        FormData.BodyPart.Strict("command", "APPEND"),
+        FormData.BodyPart.Strict("media_id", mediaId.toString),
         FormData.BodyPart.Strict("segment_index", idx.toString),
-      FormData.BodyPart.Strict("media_data", chunk.base64Data.mkString)
-    )))
-
+        FormData.BodyPart.Strict("media_data", chunk.base64Data.mkString)
+      )))
     Post(s"$mediaUrl/upload.json", formData).sendAsFormData
   }
 

--- a/src/main/scala/com/danielasfregola/twitter4s/http/serializers/JsonSupport.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/serializers/JsonSupport.scala
@@ -8,7 +8,7 @@ import org.json4s.{DefaultFormats, Formats, native}
 
 trait JsonSupport extends Json4sSupport {
 
-  implicit val serialization = native.Serialization
+  val serialization = native.Serialization
 
   implicit lazy val json4sFormats: Formats =
     defaultFormats ++ CustomSerializers.all ++ EnumSerializers.all ++ StreamingMessageSerializers.all


### PR DESCRIPTION
Fix #131

Somehow [TwitterMediaClient.appendMediaChunk](https://github.com/DanielaSfregola/twitter4s/blob/a4a13a7649f8259a9510fa469fd6c5b9a2a64a4c/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/media/TwitterMediaClient.scala#L119) is converted into `application/json` instead of `multipart/form-data` when post-ing due to custom unmarshaller related to the following akka-http [issue](https://github.com/akka/akka-http/issues/541) and akka-http-json [issue](https://github.com/hseeberger/akka-http-json/issues/148)

So, I just removed the implicit native serialization from `JsonSupport` and put it in scope where it is needed and it seems to work.

I would be glad if you had a better suggestion to solve the issue. Thanks!