### PR TITLE
Minor improvement in StreamingClient

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/StreamingClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/StreamingClient.scala
@@ -35,7 +35,7 @@ private[twitter4s] class StreamingClient(val consumerToken: ConsumerToken, val a
       for {
         requestWithAuth <- withOAuthHeader(None)(materializer)(request)
         killSwitch <- processOrFailStreamRequest(requestWithAuth)(f)
-      } yield new TwitterStream(consumerToken, accessToken)(killSwitch, requestWithAuth, system)
+      } yield TwitterStream(consumerToken, accessToken)(killSwitch, requestWithAuth, system)
     }
   }
 


### PR DESCRIPTION
Remove `new` modifier when instantiating `TwitterStream` since its a case class