### PR TITLE
Fix links to twitter docs

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/DisconnectMessage.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/DisconnectMessage.scala
@@ -8,8 +8,8 @@ import com.danielasfregola.twitter4s.entities.streaming.CommonStreamingMessage
   * Note that if the disconnect was due to network issues or a client reading too slowly,
   * it is possible that this message will not be received.
   * For more information see
-  * <a href="https://dev.twitter.com/streaming/overview/messages-types#disconnect_messages" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#disconnect_messages</a>.
+  * <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>.
   */
 final case class DisconnectMessage(disconnect: DisconnectMessageInfo) extends CommonStreamingMessage
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/LimitNotice.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/LimitNotice.scala
@@ -8,8 +8,8 @@ import com.danielasfregola.twitter4s.entities.streaming.CommonStreamingMessage
   * making them useful for tracking counts of track terms, for example.
   * Note that the counts do not specify which filter predicates undelivered messages matched.
   * For more information see
-  * <a href="https://dev.twitter.com/streaming/overview/messages-types#limit_notices" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#limit_notices</a>.
+  * <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>.
   */
 final case class LimitNotice(limit: LimitTrack) extends CommonStreamingMessage
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/LocationDeletionNotice.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/LocationDeletionNotice.scala
@@ -7,8 +7,8 @@ import com.danielasfregola.twitter4s.entities.streaming.CommonStreamingMessage
   * the given status ID and belong to the specified user. These messages may also arrive before
   * a Tweet which falls into the specified range, although this is rare.
   * For more information see
-  * <a href="https://dev.twitter.com/streaming/overview/messages-types#Location_deletion_notices_scrub_geo" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#Location_deletion_notices_scrub_geo</a>.
+  * <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>.
   */
 final case class LocationDeletionNotice(scrub_geo: LocationDeletionId) extends CommonStreamingMessage
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/StatusDeletionNotice.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/StatusDeletionNotice.scala
@@ -7,8 +7,8 @@ import com.danielasfregola.twitter4s.entities.streaming.CommonStreamingMessage
   * storage or archive, even in the rare case where a deletion message arrives earlier
   * in the stream that the Tweet it references.
   * For more information see
-  * <a href="https://dev.twitter.com/streaming/overview/messages-types#status_deletion_notices_delete" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#status_deletion_notices_delete</a>.
+  * <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>.
   */
 final case class StatusDeletionNotice(delete: StatusDeletionNoticeInfo) extends CommonStreamingMessage
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/StatusWithheldNotice.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/StatusWithheldNotice.scala
@@ -5,8 +5,8 @@ import com.danielasfregola.twitter4s.entities.streaming.CommonStreamingMessage
 /** These events contain an id field indicating the status ID, a user_id indicating the user,
   * and a collection of withheld_in_countries uppercase two-letter country codes.
   * For more information see
-  * <a href="https://dev.twitter.com/streaming/overview/messages-types#withheld_content_notices" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#withheld_content_notices</a>.
+  * <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>.
   */
 final case class StatusWithheldNotice(status_withheld: StatusWithheldId) extends CommonStreamingMessage
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/UserWithheldNotice.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/UserWithheldNotice.scala
@@ -5,8 +5,8 @@ import com.danielasfregola.twitter4s.entities.streaming.CommonStreamingMessage
 /** These events contain an id field indicating the user ID and a collection of
   * withheld_in_countries uppercase two-letter country codes.
   * For more information see
-  * <a href="https://dev.twitter.com/streaming/overview/messages-types#withheld_content_notices" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#withheld_content_notices</a>.
+  * <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>.
   */
 final case class UserWithheldNotice(user_withheld: UserWithheldId) extends CommonStreamingMessage
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/WarningMessage.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/common/WarningMessage.scala
@@ -5,8 +5,8 @@ import com.danielasfregola.twitter4s.entities.streaming.CommonStreamingMessage
 /** When connected to a stream using the stall_warnings parameter,
   * you may receive status notices indicating the current health of the connection.
   * For more information see
-  * <a href="https://dev.twitter.com/streaming/overview/messages-types#stall_warnings" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#stall_warnings</a>.
+  * <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>.
   */
 final case class WarningMessage(warning: WarningMessageInfo) extends CommonStreamingMessage
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/site/ControlMessage.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/site/ControlMessage.scala
@@ -4,8 +4,8 @@ import com.danielasfregola.twitter4s.entities.streaming.SiteStreamingMessage
 
 /** New Site Streams connections will receive a control message which may be used to modify the Site Streams connection without reconnecting.
   * See <a href="https://dev.twitter.com/streaming/sitestreams/controlstreams" target="_blank">Control Streams for Site Streams</a> for details. Note that this message will not necessarily be the first message delivered on a Site Streams connection.
-  * For more information see <a href="https://dev.twitter.com/streaming/overview/messages-types#control_messages_control" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#control_messages_control</a>
+  * For more information see <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>
   */
 final case class ControlMessage(control: ControlMessageInfo) extends SiteStreamingMessage
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/site/UserEnvelop.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/site/UserEnvelop.scala
@@ -8,8 +8,8 @@ import com.danielasfregola.twitter4s.entities.{DirectMessage, Tweet}
 /** Site Streams are sent the same messages as User Streams (including friends lists in the preamble),
   * but for multiple users instead of a single user.The same types of messages are streamed, but to identify the target of each message,
   * an additional wrapper is placed around every message, except for blank keep-alive lines.
-  * For more information see <a href="https://dev.twitter.com/streaming/overview/messages-types#envelopes_for_user" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#envelopes_for_user</a>
+  * For more information see <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>
   */
 abstract class UserEnvelop[T <: StreamingMessage](for_user: Long, message: T) extends SiteStreamingMessage
 
@@ -30,8 +30,8 @@ final case class UserEnvelopWarningMessage(for_user: Long, message: WarningMessa
 /** Site Streams are sent the same messages as User Streams (including friends lists in the preamble),
   * but for multiple users instead of a single user.The same types of messages are streamed, but to identify the target of each message,
   * an additional wrapper is placed around every message, except for blank keep-alive lines.
-  * For more information see <a href="https://dev.twitter.com/streaming/overview/messages-types#envelopes_for_user" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#envelopes_for_user</a>
+  * For more information see <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>
   */
 abstract class UserEnvelopStringified[T <: StreamingMessage](for_user: String, message: StreamingMessage) extends SiteStreamingMessage
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/user/Event.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/user/Event.scala
@@ -12,8 +12,8 @@ import com.danielasfregola.twitter4s.entities.{Tweet, TwitterList, User}
 /** Notifications about non-Tweet events are also sent over a user stream.
   * The values present will be different based on the type of event.
   * For more information see
-  * <a href="https://dev.twitter.com/streaming/overview/messages-types#Events_event" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#Events_event</a>.
+  * <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>.
   */
 abstract class Event[T](created_at: Date, event: EventCode#Value, target: User, source: User, target_object: Option[T])
     extends UserStreamingMessage

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/user/FriendsLists.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/streaming/user/FriendsLists.scala
@@ -4,15 +4,15 @@ import com.danielasfregola.twitter4s.entities.streaming.UserStreamingMessage
 
 /** Upon establishing a User Stream connection, Twitter will send a preamble before starting regular message delivery.
   * This preamble contains a list of the user’s friends. This is represented as an array of user ids as longs.
-  * For more information see <a href="https://dev.twitter.com/streaming/overview/messages-types#friends_list_friends" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#friends_list_friends</a>
+  * For more information see <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>
   */
 final case class FriendsLists(friends: Seq[Long]) extends UserStreamingMessage
 
 /** Upon establishing a User Stream connection, Twitter will send a preamble before starting regular message delivery.
   * This preamble contains a list of the user’s friends. This is represented as an array of user ids as strings.
-  * For more information see <a href="https://dev.twitter.com/streaming/overview/messages-types#friends_list_friends" target="_blank">
-  *   https://dev.twitter.com/streaming/overview/messages-types#friends_list_friends</a>
+  * For more information see <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types" target="_blank">
+  *   https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types</a>
   */
 final case class FriendsListsStringified(friends: Seq[String]) extends UserStreamingMessage
 

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/friends/TwitterFriendClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/friends/TwitterFriendClient.scala
@@ -17,8 +17,8 @@ trait TwitterFriendClient {
 
   /** Returns a cursored collection of user IDs for every user the specified user id is following (otherwise known as their “friends”).
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friends/ids" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friends/ids</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids</a>.
     *
     * @param user_id : The ID of the user for whom to return results for.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -40,8 +40,8 @@ trait TwitterFriendClient {
 
   /** Returns a cursored collection of user IDs for every user the specified user is following (otherwise known as their “friends”).
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friends/ids" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friends/ids</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -63,8 +63,8 @@ trait TwitterFriendClient {
 
   /** Returns a cursored collection of user stringified IDs for every user the specified user id is following (otherwise known as their “friends”).
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friends/ids" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friends/ids</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids</a>.
     *
     * @param user_id : The ID of the user for whom to return results for.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -86,8 +86,8 @@ trait TwitterFriendClient {
 
   /** Returns a cursored collection of user stringified IDs for every user the specified user is following (otherwise known as their “friends”).
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friends/ids" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friends/ids</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid user ID is also a valid screen name.

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/friendships/TwitterFriendshipClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/friendships/TwitterFriendshipClient.scala
@@ -17,8 +17,8 @@ trait TwitterFriendshipClient {
 
   /** Returns a collection of user ids that the currently authenticated user does not want to receive retweets from.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friendships/no_retweets/ids" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friendships/no_retweets/ids</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-no_retweets-ids" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-no_retweets-ids</a>.
     *
     * @return : The sequence of user ids the currently authenticated user does not want to receive retweets from.
     * */
@@ -29,8 +29,8 @@ trait TwitterFriendshipClient {
 
   /** Returns a collection of user stringified ids that the currently authenticated user does not want to receive retweets from.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friendships/no_retweets/ids" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friendships/no_retweets/ids</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-no_retweets-ids" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-no_retweets-ids</a>.
     *
     * @return : The sequence of the user stringified ids the currently authenticated user does not want to receive retweets from.
     * */
@@ -46,8 +46,8 @@ trait TwitterFriendshipClient {
 
   /** Returns a collection of numeric IDs for every user who has a pending request to follow the authenticating user.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friendships/incoming" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friendships/incoming</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-incoming" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-incoming</a>.
     *
     * @param cursor : By default it is `-1`,  which is the first “page”.
     *               Causes the list of blocked users to be broken into pages of no more than 5000 IDs at a time.
@@ -61,8 +61,8 @@ trait TwitterFriendshipClient {
 
   /** Returns a collection of numeric stringified IDs for every user who has a pending request to follow the authenticating user.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friendships/incoming" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friendships/incoming</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-incoming" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-incoming</a>.
     *
     * @param cursor : By default it is `-1`,  which is the first “page”.
     *               Causes the list of blocked users to be broken into pages of no more than 5000 IDs at a time.
@@ -81,8 +81,8 @@ trait TwitterFriendshipClient {
 
   /** Returns a collection of numeric IDs for every protected user for whom the authenticating user has a pending follow request.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friendships/outgoing" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friendships/outgoing</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-outgoing" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-outgoing</a>.
     *
     * @param cursor : By default it is `-1`,  which is the first “page”.
     *               Causes the list of blocked users to be broken into pages of no more than 5000 IDs at a time.
@@ -96,8 +96,8 @@ trait TwitterFriendshipClient {
 
   /** Returns a collection of numeric stringified IDs for every protected user for whom the authenticating user has a pending follow request.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friendships/outgoing" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friendships/outgoing</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-outgoing" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-outgoing</a>.
     *
     * @param cursor : By default it is `-1`,  which is the first “page”.
     *               Causes the list of blocked users to be broken into pages of no more than 5000 IDs at a time.
@@ -116,8 +116,8 @@ trait TwitterFriendshipClient {
 
   /** Allows the authenticating users to follow the specified user id.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/post/friendships/create" target="_blank">
-    *   https://dev.twitter.com/rest/reference/post/friendships/create</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/post-friendships-create" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/post-friendships-create</a>.
     *
     * @param user_id : The ID of the user for whom to befriend.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -303,8 +303,8 @@ trait TwitterFriendshipClient {
 
   /** Returns detailed information about the relationship between two arbitrary users ids.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friendships/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friendships/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-show</a>.
     *
     * @param source_id : The user id of the subject user.
     * @param target_id : The user id of the target user.
@@ -317,8 +317,8 @@ trait TwitterFriendshipClient {
 
   /** Returns detailed information about the relationship between two arbitrary users.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friendships/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friendships/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-show</a>.
     *
     * @param source_screen_name : The screen name of the subject user.
     * @param target_screen_name : The screen name of the target user.
@@ -337,8 +337,8 @@ trait TwitterFriendshipClient {
   /** Returns the relationships of the authenticating user of up to 100 user screen names.
     * Values for connections can be: `following`, `following_requested`, `followed_by`, `none`, `blocking`, `muting`.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friendships/lookup" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friendships/lookup</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup</a>.
     *
     * @param screen_names :  The list of screen names.
     *                     At least 1 screen name needs to be provided. Up to 100 are allowed in a single request.
@@ -354,8 +354,8 @@ trait TwitterFriendshipClient {
   /** Returns the relationships of the authenticating user of up to 100 user ids.
     * Values for connections can be: `following`, `following_requested`, `followed_by`, `none`, `blocking`, `muting`.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friendships/lookup" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friendships/lookup</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup</a>.
     *
     * @param user_ids :  The list of user ids.
     *                 At least 1 user id needs to be provided. Up to 100 are allowed in a single request.

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/sites/TwitterSiteClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/sites/TwitterSiteClient.scala
@@ -17,32 +17,32 @@ trait TwitterSiteClient {
 
   private val siteUrl = s"$siteStreamingTwitterUrl/$twitterVersion"
 
-  /** Starts a streaming connection from Twitter's site API. SStreams messages for a set of users,
-    * as described in <a href="https://dev.twitter.com/streaming/sitestreams" target="_blank">Site streams</a>.
+  /** Starts a streaming connection from Twitter's site API. Streams messages for a set of users,
+    * as described in <a href="https://developer.twitter.com/en/docs/tutorials/consuming-streaming-data" target="_blank">Site streams</a>.
     * The function returns a future of a `TwitterStream` that can be use to close or replace the stream when needed.
     * If there are failures in establishing the initial connection, the Future returned will be completed with a failure.
     * Since it's an asynchronous event stream, all the events will be parsed as entities of type `SiteStreamingMessage`
     * and processed accordingly to the partial function `f`. All the messages that do not match `f` are automatically ignored.
     * For more information see
-    * <a href="https://dev.twitter.com/streaming/reference/get/site" target="_blank">
-    *   https://dev.twitter.com/streaming/reference/get/site</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/site-stream" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/site-stream</a>.
     *
     * @param follow : Empty by default. A comma separated list of user IDs, indicating the users to return statuses for in the stream.
-    *                 For more information <a href="https://dev.twitter.com/streaming/overview/request-parameters#follow" target="_blank">
-    *                   https://dev.twitter.com/streaming/overview/request-parameters#follow</a>
+    *                 For more information <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/site-stream" target="_blank">
+    *                   https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/site-stream</a>
     * @param with: `User` by default. Specifies whether to return information for just the users specified in the follow parameter, or include messages from accounts they follow.
-    *              For more information see <a href="https://dev.twitter.com/streaming/overview/request-parameters" target="_blank">
-    *                https://dev.twitter.com/streaming/overview/request-parameters</a>
+    *              For more information see <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/site-stream" target="_blank">
+    *                https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/site-stream</a>
     * @param replies: Optional. By default @replies are only sent if the current user follows both the sender and receiver of the reply.
     *                 To receive all the replies, set the argument to `true`.
-    *                 For more information see <a href="https://dev.twitter.com/streaming/overview/request-parameters#replies" target="_blank">
-    *                   https://dev.twitter.com/streaming/overview/request-parameters#replies</a>
+    *                 For more information see <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/site-stream" target="_blank">
+    *                   https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/site-stream</a>
     * @param stringify_friend_ids: Optional. Specifies whether to send the Friend List preamble as an array of integers or an array of strings.
-    *                              For more information see <a href="https://dev.twitter.com/streaming/overview/request-parameters#stringify_friend_id" tagert="_blank">
-    *                                https://dev.twitter.com/streaming/overview/request-parameters#stringify_friend_id</a>
+    *                              For more information see <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/site-stream" tagert="_blank">
+    *                                https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/site-stream</a>
     * @param languages : Empty by default. A comma separated list of 'BCP 47' language identifiers.
-    *                    For more information <a href="https://dev.twitter.com/streaming/overview/request-parameters#language" target="_blank">
-    *                      https://dev.twitter.com/streaming/overview/request-parameters#language</a>
+    *                    For more information <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters" target="_blank">
+    *                      https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters</a>
     * @param stall_warnings : Default to false. Specifies whether stall warnings (`WarningMessage`) should be delivered as part of the updates.
     * @param f: the function that defines how to process the received messages
     */


### PR DESCRIPTION
I noticed the work on #149 and noticed that while most of the links are fixed there are still some left. Most of them are actually being redirected to the right page, but others are being redirected to a generic streaming tutorial. I started fixing the ones left pointing to `dev.*`  but wanted to get some feedback before going further.

Do you want to fix all links to `dev.*` and replace them with the appropriate link to `developer.*`?