### PR TITLE
Fix links to twitter docs (part deux)

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/account/TwitterAccountClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/account/TwitterAccountClient.scala
@@ -21,8 +21,8 @@ trait TwitterAccountClient {
 
   /** Returns settings (including current trend, geo and sleep time information) for the authenticating user.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/account/settings" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/account/settings</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-settings" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-settings</a>.
     *
     * @return : The account settings for the authenticating user.
     * */
@@ -86,8 +86,8 @@ trait TwitterAccountClient {
   /** Returns a representation of the requesting user if authentication was successful; it throws a [[com.danielasfregola.twitter4s.exceptions.TwitterException]] if not.
     * Use this method to test if supplied user credentials are valid.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/account/verify_credentials" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/account/verify_credentials</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials</a>.
     *
     * @param include_entities : By default it is `true`.
     *                         The parameters node will not be included when set to false.

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/favorites/TwitterFavoriteClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/favorites/TwitterFavoriteClient.scala
@@ -17,8 +17,8 @@ trait TwitterFavoriteClient {
 
   /** Returns the 20 most recent Tweets liked by the specified user.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/favorites/list" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/favorites/list</a>.
+    * <a href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-favorites-list" target="_blank">
+    *   https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-favorites-list</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -48,8 +48,8 @@ trait TwitterFavoriteClient {
 
   /** Returns the 20 most recent Tweets liked by the specified user id.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/favorites/list" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/favorites/list</a>.
+    * <a href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-favorites-list" target="_blank">
+    *   https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-favorites-list</a>.
     *
     * @param user_id : The ID of the user for whom to return results for.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -86,8 +86,8 @@ trait TwitterFavoriteClient {
     * Note: the like action was known as favorite before November 3, 2015;
     * the historical naming remains in API methods and object properties.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/post/favorites/create" target="_blank">
-    *   https://dev.twitter.com/rest/reference/post/favorites/create</a>.
+    * <a href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-favorites-create" target="_blank">
+    *   https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-favorites-create</a>.
     *
     * @param id : The numerical ID of the desired status.
     * @param include_entities : By default it is `true`.
@@ -104,8 +104,8 @@ trait TwitterFavoriteClient {
     * Note: the like action was known as favorite before November 3, 2015;
     * the historical naming remains in API methods and object properties.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/post/favorites/destroy" target="_blank">
-    *   https://dev.twitter.com/rest/reference/post/favorites/destroy</a>.
+    * <a href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-favorites-destroy" target="_blank">
+    *   https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-favorites-destroy</a>.
     *
     * @param id : The numerical ID of the desired status.
     * @param include_entities : By default it is `true`.

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/followers/TwitterFollowerClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/followers/TwitterFollowerClient.scala
@@ -17,8 +17,8 @@ trait TwitterFollowerClient {
 
   /** Returns a cursored collection of user IDs for every user following the specified user id.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/followers/ids" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/followers/ids</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids</a>.
     *
     * @param user_id : The ID of the user for whom to return results for.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -40,8 +40,8 @@ trait TwitterFollowerClient {
 
   /** Returns a cursored collection of user IDs for every user following the specified user.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/followers/ids" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/followers/ids</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -63,8 +63,8 @@ trait TwitterFollowerClient {
 
   /** Returns a cursored collection of user stringified IDs for every user following the specified user id.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/followers/ids" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/followers/ids</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids</a>.
     *
     * @param user_id : The ID of the user for whom to return results for.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -86,8 +86,8 @@ trait TwitterFollowerClient {
 
   /** Returns a cursored collection of user stringified IDs for every user following the specified user.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/followers/ids" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/followers/ids</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -114,8 +114,8 @@ trait TwitterFollowerClient {
 
   /** Returns a cursored collection of user objects for users following the specified user.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/followers/list" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/followers/list</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-list" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-list</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -142,8 +142,8 @@ trait TwitterFollowerClient {
 
   /** Returns a cursored collection of user objects for users following the specified user id.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/followers/list" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/followers/list</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-list" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-list</a>.
     *
     * @param user_id : The screen name of the user for whom to return results for.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/friends/TwitterFriendClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/friends/TwitterFriendClient.scala
@@ -114,8 +114,8 @@ trait TwitterFriendClient {
 
   /** Returns a cursored collection of user objects for every user the specified user is following (otherwise known as their “friends”).
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friends/list" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friends/list</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-list" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-list</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -142,8 +142,8 @@ trait TwitterFriendClient {
 
   /** Returns a cursored collection of user objects for every user the specified user id is following (otherwise known as their “friends”).
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/friends/list" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/friends/list</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-list" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-list</a>.
     *
     * @param user_id : The ID of the user for whom to return results for.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/lists/TwitterListClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/lists/TwitterListClient.scala
@@ -265,8 +265,8 @@ trait TwitterListClient {
 
   /** Returns the twitter lists the specified user has been added to.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/memberships" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/memberships</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-memberships" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-memberships</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid screen name is also a user ID.
@@ -289,8 +289,8 @@ trait TwitterListClient {
 
   /** Returns the twitter lists the specified user has been added to.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/memberships" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/memberships</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-memberships" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-memberships</a>.
     *
     * @param user_id : The ID of the user for whom to return results for.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -430,8 +430,8 @@ trait TwitterListClient {
   /** Check if the specified user is a member of the specified list.
     * If the user is a member of the specified list, his user representation is returned.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/members/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/members/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show</a>.
     *
     * @param list_id : The numerical id of the list.
     * @param user_id : The ID of the user for whom to return results for.
@@ -457,8 +457,8 @@ trait TwitterListClient {
   /** Check if the specified user is a member of the specified list.
     * If the user is a member of the specified list, his user representation is returned.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/members/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/members/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show</a>.
     *
     * @param slug : You can identify a list by its slug instead of its numerical id.
     * @param owner_screen_name : The screen name of the user who owns the list being requested by a `slug`.
@@ -487,8 +487,8 @@ trait TwitterListClient {
   /** Check if the specified user is a member of the specified list.
     * If the user is a member of the specified list, his user representation is returned.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/members/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/members/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show</a>.
     *
     * @param slug : You can identify a list by its slug instead of its numerical id.
     * @param owner_id : The user ID of the user who owns the list being requested by a `slug`.
@@ -517,8 +517,8 @@ trait TwitterListClient {
   /** Check if the specified user is a member of the specified list.
     * If the user is a member of the specified list, his user representation is returned.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/members/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/members/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show</a>.
     *
     * @param list_id : The numerical id of the list.
     * @param screen_name : The screen name of the user for whom to return results for.
@@ -544,8 +544,8 @@ trait TwitterListClient {
   /** Check if the specified user is a member of the specified list.
     * If the user is a member of the specified list, his user representation is returned.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/members/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/members/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show</a>.
     *
     * @param slug : You can identify a list by its slug instead of its numerical id.
     * @param owner_screen_name : The screen name of the user who owns the list being requested by a `slug`.
@@ -574,8 +574,8 @@ trait TwitterListClient {
   /** Check if the specified user is a member of the specified list.
     * If the user is a member of the specified list, his user representation is returned.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/members/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/members/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show</a>.
     *
     * @param slug : You can identify a list by its slug instead of its numerical id.
     * @param owner_id : The user ID of the user who owns the list being requested by a `slug`.
@@ -608,8 +608,8 @@ trait TwitterListClient {
 
   /** Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/members" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/members</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members</a>.
     *
     * @param list_id : The numerical id of the list.
     * @param count : By default it is `20`.
@@ -639,8 +639,8 @@ trait TwitterListClient {
 
   /** Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/members" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/members</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members</a>.
     *
     * @param slug : You can identify a list by its slug instead of its numerical id.
     * @param owner_screen_name : The screen name of the user who owns the list being requested by a `slug`.
@@ -673,8 +673,8 @@ trait TwitterListClient {
 
   /** Returns the members of the specified list. Private list members will only be shown if the authenticated user owns the specified list.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/members" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/members</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members</a>.
     *
     * @param slug : You can identify a list by its slug instead of its numerical id.
     * @param owner_id : The user ID of the user who owns the list being requested by a `slug`.
@@ -1063,8 +1063,8 @@ trait TwitterListClient {
 
   /** Returns the specified list. Private lists will only be shown if the authenticated user owns the specified list.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-show</a>.
     *
     * @param list_id : The numerical id of the list.
     * @return : The Twitter list.
@@ -1076,8 +1076,8 @@ trait TwitterListClient {
 
   /** Returns the specified list. Private lists will only be shown if the authenticated user owns the specified list.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-show</a>.
     *
     * @param slug : You can identify a list by its slug instead of its numerical id.
     * @param owner_screen_name : The screen name of the user who owns the list being requested by a `slug`.
@@ -1090,8 +1090,8 @@ trait TwitterListClient {
 
   /** Returns the specified list. Private lists will only be shown if the authenticated user owns the specified list.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/show" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/show</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-show" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-show</a>.
     *
     * @param slug : You can identify a list by its slug instead of its numerical id.
     * @param owner_id : The user ID of the user who owns the list being requested by a `slug`.
@@ -1110,8 +1110,8 @@ trait TwitterListClient {
   /** Obtain a collection of the lists the specified user is subscribed to, 20 lists per page by default.
     * Does not include the user’s own lists.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/subscriptions" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/subscriptions</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-subscriptions" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-subscriptions</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid screen name is also a user ID.
@@ -1132,8 +1132,8 @@ trait TwitterListClient {
   /** Obtain a collection of the lists the specified user is subscribed to, 20 lists per page by default.
     * Does not include the user’s own lists.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/subscriptions" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/subscriptions</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-subscriptions" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-subscriptions</a>.
     *
     * @param user_id : The ID of the user for whom to return results for.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -1272,8 +1272,8 @@ trait TwitterListClient {
   /** Returns the lists owned by the specified Twitter user.
     * Private lists will only be shown if the authenticated user is also the owner of the lists.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/ownerships" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/ownerships</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-ownerships" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-ownerships</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid screen name is also a user ID.
@@ -1292,8 +1292,8 @@ trait TwitterListClient {
   /** Returns the lists owned by the specified Twitter user.
     * Private lists will only be shown if the authenticated user is also the owner of the lists.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/ownerships" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/ownerships</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-ownerships" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-ownerships</a>.
     *
     * @param user_id : The ID of the user for whom to return results for.
     * @param count : By default it is `20`.

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/lists/TwitterListClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/lists/TwitterListClient.scala
@@ -19,8 +19,8 @@ trait TwitterListClient {
 
   /** Returns all lists the specified user subscribes to, including their own.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/list" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/list</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-list" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-list</a>.
     *
     * @param screen_name : The screen name of the user for whom to return results for.
     *                    Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -35,8 +35,8 @@ trait TwitterListClient {
 
   /** Returns all lists the specified user subscribes to, including their own.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/list" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/list</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-list" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-list</a>.
     *
     * @param user_id : The ID of the user for whom to return results for.
     *                Helpful for disambiguating when a valid user ID is also a valid screen name.
@@ -56,8 +56,8 @@ trait TwitterListClient {
 
   /** Returns a timeline of tweets authored by members of the specified list.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/statuses" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/statuses</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses</a>.
     *
     * @param slug : You can identify a list by its slug instead of its numerical id.
     * @param owner_id : The user ID of the user who owns the list being requested by a `slug`.
@@ -91,8 +91,8 @@ trait TwitterListClient {
 
   /** Returns a timeline of tweets authored by members of the specified list.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/statuses" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/statuses</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses</a>.
     *
     * @param slug : You can identify a list by its slug instead of its numerical id.
     * @param owner_screen_name : TThe screen name of the user who owns the list being requested by a `slug`.
@@ -126,8 +126,8 @@ trait TwitterListClient {
 
   /** Returns a timeline of tweets authored by members of the specified list.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/get/lists/statuses" target="_blank">
-    *   https://dev.twitter.com/rest/reference/get/lists/statuses</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses</a>.
     *
     * @param list_id : The numerical id of the list.
     * @param count : By default it is `20`.

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/mutes/TwitterMuteClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/mutes/TwitterMuteClient.scala
@@ -53,8 +53,8 @@ trait TwitterMuteClient {
   /** Un-mutes the user specified for the authenticating user.
     * Actions taken in this method are asynchronous and changes will be eventually consistent.
     * For more information see
-    * <a href="https://dev.twitter.com/rest/reference/post/mutes/users/destroy" target="_blank">
-    *   https://dev.twitter.com/rest/reference/post/mutes/users/destroy</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-destroy" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-destroy</a>.
     *
     * @param screen_name : The screen name of the potentially muted user.
     *                    Helpful for disambiguating when a valid screen name is also a user ID.

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/statuses/TwitterStatusClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/statuses/TwitterStatusClient.scala
@@ -27,17 +27,17 @@ trait TwitterStatusClient {
     *   https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter.html</a>.
     *
     * @param follow : Empty by default. A comma separated list of user IDs, indicating the users to return statuses for in the stream.
-    *                 For more information <a href="https://dev.twitter.com/streaming/overview/request-parameters#follow" target="_blank">
-    *                   https://dev.twitter.com/streaming/overview/request-parameters#follow</a>
+    *                 For more information <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter.html" target="_blank">
+    *                   https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter.html</a>
     * @param tracks : Empty by default. Keywords to track. Phrases of keywords are specified by a comma-separated list.
-    *                For more information <a href="https://dev.twitter.com/streaming/overview/request-parameters#track" target="_blank">
-    *                  https://dev.twitter.com/streaming/overview/request-parameters#track</a>
+    *                For more information <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter.html" target="_blank">
+    *                  https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter.html</a>
     * @param locations : Empty by default. Specifies a set of bounding boxes to track.
-    *                    For more information <a href="https://dev.twitter.com/streaming/overview/request-parameters#locations" target="_blank">
-    *                      https://dev.twitter.com/streaming/overview/request-parameters#locations</a>
+    *                    For more information <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter.html" target="_blank">
+    *                      https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter.html</a>
     * @param languages : Empty by default. A comma separated list of 'BCP 47' language identifiers.
-    *                    For more information <a href="https://dev.twitter.com/streaming/overview/request-parameters#language" target="_blank">
-    *                      https://dev.twitter.com/streaming/overview/request-parameters#language</a>
+    *                    For more information <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters" target="_blank">
+    *                      https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters</a>
     * @param stall_warnings : Default to false. Specifies whether stall warnings (`WarningMessage`) should be delivered as part of the updates.
     * @param f: the function that defines how to process the received messages
     */
@@ -64,8 +64,8 @@ trait TwitterStatusClient {
     *   https://developer.twitter.com/en/docs/tweets/sample-realtime/overview/GET_statuse_sample</a>.
     *
     * @param languages : Empty by default. A comma separated list of 'BCP 47' language identifiers.
-    *                    For more information <a href="https://dev.twitter.com/streaming/overview/request-parameters#language" target="_blank">
-    *                      https://dev.twitter.com/streaming/overview/request-parameters#language</a>
+    *                    For more information <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters" target="_blank">
+    *                      https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters</a>
     * @param stall_warnings : Default to false. Specifies whether stall warnings (`WarningMessage`) should be delivered as part of the updates.
     * @param f: the function that defines how to process the received messages
     */
@@ -92,8 +92,8 @@ trait TwitterStatusClient {
     *               For more information see <a href="https://dev.twitter.com/streaming/overview/request-parameters#count" target="_blank">
     *                 https://dev.twitter.com/streaming/overview/request-parameters#count</a>
     * @param languages : Empty by default. A comma separated list of 'BCP 47' language identifiers.
-    *                    For more information <a href="https://dev.twitter.com/streaming/overview/request-parameters#language" target="_blank">
-    *                      https://dev.twitter.com/streaming/overview/request-parameters#language</a>
+    *                    For more information <a href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters" target="_blank">
+    *                      https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters</a>
     * @param stall_warnings : Default to false. Specifies whether stall warnings (`WarningMessage`) should be delivered as part of the updates.
     * @param f: the function that defines how to process the received messages.
     */

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/users/TwitterUserClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/users/TwitterUserClient.scala
@@ -18,7 +18,7 @@ trait TwitterUserClient {
   private val userUrl = s"$userStreamingTwitterUrl/$twitterVersion"
 
   /** Starts a streaming connection from Twitter's user API. Streams messages for a single user as
-    * described in <a href="https://dev.twitter.com/streaming/userstreams" target="_blank">User streams</a>.
+    * described in <a href="https://developer.twitter.com/en/docs/tutorials/consuming-streaming-data" target="_blank">User streams</a>.
     * The function returns a future of a `TwitterStream` that can be use to close or replace the stream when needed.
     * If there are failures in establishing the initial connection, the Future returned will be completed with a failure.
     * Since it's an asynchronous event stream, all the events will be parsed as entities of type `UserStreamingMessage`
@@ -29,24 +29,24 @@ trait TwitterUserClient {
     *
     * @param with: `Followings` by default. Specifies whether to return information for just the authenticating user,
     *              or include messages from accounts the user follows.
-    *              For more information see <a href="https://dev.twitter.com/streaming/overview/request-parameters" target="_blank">
-    *                https://dev.twitter.com/streaming/overview/request-parameters</a>
+    *              For more information see <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream" target="_blank">
+    *                https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream</a>
     * @param replies: Optional. By default @replies are only sent if the current user follows both the sender and receiver of the reply.
     *                 To receive all the replies, set the argument to `true`.
-    *                 For more information see <a href="https://dev.twitter.com/streaming/overview/request-parameters#replies" target="_blank">
-    *                   https://dev.twitter.com/streaming/overview/request-parameters#replies</a>
+    *                 For more information see <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream" target="_blank">
+    *                   https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream</a>
     * @param tracks : Empty by default. Keywords to track. Phrases of keywords are specified by a comma-separated list.
-    *                For more information see <a href="https://dev.twitter.com/streaming/overview/request-parameters#track" target="_blank">
-    *                  https://dev.twitter.com/streaming/overview/request-parameters#track</a>
+    *                For more information see <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream" target="_blank">
+    *                  https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream</a>
     * @param locations : Empty by default. Specifies a set of bounding boxes to track.
-    *                    For more information see <a href="https://dev.twitter.com/streaming/overview/request-parameters#locations" target="_blank">
-    *                      https://dev.twitter.com/streaming/overview/request-parameters#locations</a>
+    *                    For more information see <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream" target="_blank">
+    *                      https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream</a>
     * @param stringify_friend_ids: Optional. Specifies whether to send the Friend List preamble as an array of integers or an array of strings.
-    *                              For more information see <a href="https://dev.twitter.com/streaming/overview/request-parameters#stringify_friend_id" tagert="_blank">
-    *                                https://dev.twitter.com/streaming/overview/request-parameters#stringify_friend_id</a>
+    *                              For more information see <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream" tagert="_blank">
+    *                                https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream</a>
     * @param languages : Empty by default. A comma separated list of 'BCP 47' language identifiers.
-    *                    For more information <a href="https://dev.twitter.com/streaming/overview/request-parameters#language" target="_blank">
-    *                      https://dev.twitter.com/streaming/overview/request-parameters#language</a>
+    *                    For more information <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream" target="_blank">
+    *                      https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream</a>
     * @param stall_warnings : Default to false. Specifies whether stall warnings (`WarningMessage`) should be delivered as part of the updates.
     * @param f: the function that defines how to process the received messages
     */

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/users/TwitterUserClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/users/TwitterUserClient.scala
@@ -24,8 +24,8 @@ trait TwitterUserClient {
     * Since it's an asynchronous event stream, all the events will be parsed as entities of type `UserStreamingMessage`
     * and processed accordingly to the partial function `f`. All the messages that do not match `f` are automatically ignored.
     * For more information see
-    * <a href="https://dev.twitter.com/streaming/reference/get/statuses/sample" target="_blank">
-    *   https://dev.twitter.com/streaming/reference/get/statuses/sample</a>.
+    * <a href="https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream" target="_blank">
+    *   https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/user-stream</a>.
     *
     * @param with: `Followings` by default. Specifies whether to return information for just the authenticating user,
     *              or include messages from accounts the user follows.


### PR DESCRIPTION
This should fix almost all of the documentation links for #149 

I wasn’t able to find proper links for these two instances:

1. `http/clients/streaming/statuses/TwitterStatusClient.scala` is linking to `https://dev.twitter.com/streaming/reference/get/statuses/firehose` which returns a 404

2. `entities/streaming/site/ControlMessage.scala` is linking to  `https://dev.twitter.com/streaming/sitestreams/controlstreams` which redirects to something very generic.

Both instances I couldn’t find in the [API reference index — Twitter      Developers](https://developer.twitter.com/en/docs/api-reference-index) for that matter.

If you need me to rebase these commits in some form, let me know.