### PR TITLE
Fix location filter parameters for streaming client

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/entities/Coordinate.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/Coordinate.scala
@@ -1,0 +1,6 @@
+package com.danielasfregola.twitter4s.entities
+
+final case class Coordinate(longitude: Double, latitude: Double) {
+  def toLngLatPair: (Double, Double) =
+    (longitude, latitude)
+}

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/GeoBoundingBox.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/GeoBoundingBox.scala
@@ -1,0 +1,12 @@
+package com.danielasfregola.twitter4s.entities
+
+final case class GeoBoundingBox(southwest: Coordinate, northeast: Coordinate) {
+  def toLngLatPairs: Seq[(Double, Double)] =
+    Seq(southwest.toLngLatPair, northeast.toLngLatPair)
+}
+
+object GeoBoundingBox {
+  def toLngLatPairs(boundingBoxes: Seq[GeoBoundingBox]): Seq[(Double, Double)] = {
+    boundingBoxes.flatMap(_.toLngLatPairs)
+  }
+}

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/statuses/TwitterStatusClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/statuses/TwitterStatusClient.scala
@@ -1,6 +1,8 @@
 package com.danielasfregola.twitter4s
 package http.clients.streaming.statuses
 
+import com.danielasfregola.twitter4s.entities.GeoBoundingBox
+import com.danielasfregola.twitter4s.entities.GeoBoundingBox.toLngLatPairs
 import com.danielasfregola.twitter4s.entities.enums.FilterLevel
 import com.danielasfregola.twitter4s.entities.enums.FilterLevel.FilterLevel
 import com.danielasfregola.twitter4s.entities.enums.Language.Language
@@ -48,13 +50,13 @@ trait TwitterStatusClient {
     */
   def filterStatuses(follow: Seq[Long] = Seq.empty,
                      tracks: Seq[String] = Seq.empty,
-                     locations: Seq[Double] = Seq.empty,
+                     locations: Seq[GeoBoundingBox] = Seq.empty,
                      languages: Seq[Language] = Seq.empty,
                      stall_warnings: Boolean = false,
                      filter_level: FilterLevel = FilterLevel.None)(f: PartialFunction[CommonStreamingMessage, Unit]): Future[TwitterStream] = {
     import streamingClient._
     require(follow.nonEmpty || tracks.nonEmpty || locations.nonEmpty, "At least one of 'follow', 'tracks' or 'locations' needs to be non empty")
-    val filters = StatusFilters(follow, tracks, locations, languages, stall_warnings, filter_level)
+    val filters = StatusFilters(follow, tracks, toLngLatPairs(locations), languages, stall_warnings, filter_level)
     preProcessing()
     Post(s"$statusUrl/filter.json", filters).processStream(f)
   }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/statuses/parameters/StatusFilters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/statuses/parameters/StatusFilters.scala
@@ -5,7 +5,7 @@ import com.danielasfregola.twitter4s.entities.enums.Language.Language
 
 private[twitter4s] final case class StatusFilters(follow: Seq[Long],
                                             track: Seq[String],
-                                            locations: Seq[Double],
+                                            locations: Seq[(Double, Double)],
                                             language: Seq[Language],
                                             stall_warnings: Boolean,
                                             filter_level: FilterLevel)

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/users/TwitterUserClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/users/TwitterUserClient.scala
@@ -1,6 +1,8 @@
 package com.danielasfregola.twitter4s
 package http.clients.streaming.users
 
+import com.danielasfregola.twitter4s.entities.GeoBoundingBox
+import com.danielasfregola.twitter4s.entities.GeoBoundingBox.toLngLatPairs
 import com.danielasfregola.twitter4s.entities.enums.FilterLevel.FilterLevel
 import com.danielasfregola.twitter4s.entities.enums.Language.Language
 import com.danielasfregola.twitter4s.entities.enums.{FilterLevel, WithFilter}
@@ -55,14 +57,14 @@ trait TwitterUserClient {
   def userEvents(`with`: WithFilter = WithFilter.Followings,
                  replies: Option[Boolean] = None,
                  tracks: Seq[String] = Seq.empty,
-                 locations: Seq[Double] = Seq.empty,
+                 locations: Seq[GeoBoundingBox] = Seq.empty,
                  stringify_friend_ids: Boolean = false,
                  languages: Seq[Language] = Seq.empty,
                  stall_warnings: Boolean = false,
                  filter_level: FilterLevel = FilterLevel.None)(f: PartialFunction[UserStreamingMessage, Unit]): Future[TwitterStream] = {
     import streamingClient._
     val repliesAll = replies.flatMap(x => if (x) Some("all") else None)
-    val parameters = UserParameters(`with`, repliesAll, tracks, locations, stringify_friend_ids, languages, stall_warnings, filter_level)
+    val parameters = UserParameters(`with`, repliesAll, tracks, toLngLatPairs(locations), stringify_friend_ids, languages, stall_warnings, filter_level)
     preProcessing()
     Get(s"$userUrl/user.json", parameters).processStream(f)
   }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/users/parameters/UserParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/users/parameters/UserParameters.scala
@@ -8,7 +8,7 @@ import com.danielasfregola.twitter4s.http.marshalling.Parameters
 private[twitter4s] final case class UserParameters(`with`: WithFilter,
                                              replies: Option[String],
                                              track: Seq[String],
-                                             locations: Seq[Double],
+                                             locations: Seq[(Double, Double)],
                                              stringify_friend_ids: Boolean,
                                              language: Seq[Language],
                                              stall_warnings: Boolean,

--- a/src/main/scala/com/danielasfregola/twitter4s/http/marshalling/BodyEncoder.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/marshalling/BodyEncoder.scala
@@ -17,6 +17,10 @@ trait BodyEncoder {
 
   private def toBodyAsMap(cc: Product): Map[String, String] =
     asMap(cc).flatMap {
+      case (k, (v1, v2) :: tail) =>
+        val rest = tail.map { case (a, b) => s"$a,$b" }
+        val flattened = s"$v1,$v2" :: rest
+        Some(k -> flattened.mkString(","))
       case (k, head :: tail) => Some(k -> (head +: tail).mkString(","))
       case (_, Nil) => None
       case (_, None) => None

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/streaming/statuses/TwitterStatusClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/streaming/statuses/TwitterStatusClientSpec.scala
@@ -1,6 +1,7 @@
 package com.danielasfregola.twitter4s.http.clients.streaming.statuses
 
 import akka.http.scaladsl.model.{HttpEntity, HttpMethods}
+import com.danielasfregola.twitter4s.entities.{GeoBoundingBox, Coordinate}
 import com.danielasfregola.twitter4s.entities.enums.Language
 import com.danielasfregola.twitter4s.helpers.ClientSpec
 
@@ -11,15 +12,17 @@ class TwitterStatusClientSpec extends ClientSpec {
   "Twitter Status Streaming Client" should {
 
     "start a filtered status stream" in new TwitterStatusClientSpecContext {
+      val locationsFilter = Seq(GeoBoundingBox(Coordinate(-122.75, 36.8), Coordinate(-121.75, 37.8)))
       val result: Unit =
         when(filterStatuses(follow = Seq(1L, 2L, 3L),
                             tracks = Seq("trending", "other"),
+                            locations = locationsFilter,
                             languages = Seq(Language.Hungarian, Language.Bengali))(dummyProcessing))
           .expectRequest { request =>
             request.method === HttpMethods.POST
             request.uri.endpoint === "https://stream.twitter.com/1.1/statuses/filter.json"
             request.entity === HttpEntity(`application/x-www-form-urlencoded`,
-                                          "filter_level=none&follow=1%2C2%2C3&language=hu%2Cbn&stall_warnings=false&track=trending%2Cother")
+                                          "filter_level=none&follow=1%2C2%2C3&language=hu%2Cbn&locations=-122.75%2C36.8%2C-121.75%2C37.8&stall_warnings=false&track=trending%2Cother")
           }
           .respondWithOk
           .await

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/streaming/users/TwitterUserClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/streaming/users/TwitterUserClientSpec.scala
@@ -1,6 +1,7 @@
 package com.danielasfregola.twitter4s.http.clients.streaming.users
 
 import akka.http.scaladsl.model.HttpMethods
+import com.danielasfregola.twitter4s.entities.{GeoBoundingBox, Coordinate}
 import com.danielasfregola.twitter4s.entities.enums.Language
 import com.danielasfregola.twitter4s.helpers.ClientSpec
 
@@ -11,12 +12,21 @@ class TwitterUserClientSpec extends ClientSpec {
   "Twitter User Streaming Client" should {
 
     "start a filtered user stream" in new TwitterUserClientSpecContext {
+      val locationsFilter = Seq(
+        GeoBoundingBox(Coordinate(-122.75, 36.8), Coordinate(-121.75, 37.8)),
+        GeoBoundingBox(Coordinate(-74, 40), Coordinate(-73, 41))
+      )
       val result: Unit =
-        when(userEvents(tracks = Seq("trending"), languages = Seq(Language.English))(dummyProcessing)).expectRequest { request =>
-          request.method === HttpMethods.GET
-          request.uri.endpoint === "https://userstream.twitter.com/1.1/user.json"
-          request.uri.queryString() === Some("filter_level=none&language=en&stall_warnings=false&stringify_friend_ids=false&track=trending&with=followings")
-        }.respondWithOk.await
+        when(userEvents(tracks = Seq("trending"),
+                        languages = Seq(Language.English),
+                        locations = locationsFilter)(dummyProcessing))
+          .expectRequest { request =>
+            request.method === HttpMethods.GET
+            request.uri.endpoint === "https://userstream.twitter.com/1.1/user.json"
+            request.uri.queryString() === Some("filter_level=none&language=en&locations=-122.75,36.8,-121.75,37.8,-74.0,40.0,-73.0,41.0&stall_warnings=false&stringify_friend_ids=false&track=trending&with=followings")
+          }
+          .respondWithOk
+          .await
       result.isInstanceOf[Unit] should beTrue
     }
   }

--- a/src/test/scala/com/danielasfregola/twitter4s/http/marshalling/BodyEncoderSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/marshalling/BodyEncoderSpec.scala
@@ -7,19 +7,20 @@ class BodyEncoderSpec extends Specification with BodyEncoder {
   "BodyEncoder" should {
 
     "encode a case class to a body with encoded params" in {
-      case class TestData(d: Seq[Long], c: String, b: Option[Boolean], a: Int)
+      case class TestData(e: Seq[(Double, Double)], d: Seq[Long], c: String, b: Option[Boolean], a: Int)
 
-      val test = TestData(Seq(1,2,3),"Hello Ladies + Gentlemen, a signed OAuth request!", None, 5)
+      val test = TestData(Seq((1,2), (3,4)), Seq(1,2,3),"Hello Ladies + Gentlemen, a signed OAuth request!", None, 5)
       val result = toBodyAsEncodedParams(test)
-      result === "a=5&c=Hello+Ladies+%2B+Gentlemen%2C+a+signed+OAuth+request%21&d=1%2C2%2C3"
+      println(result)
+      result === "a=5&c=Hello+Ladies+%2B+Gentlemen%2C+a+signed+OAuth+request%21&d=1%2C2%2C3&e=1.0%2C2.0%2C3.0%2C4.0"
     }
 
     "encode a case class to a body with params" in {
-      case class TestData(d: Seq[Long], c: String, b: Option[Boolean], a: Int)
+      case class TestData(e: Seq[(Double, Double)], d: Seq[Long], c: String, b: Option[Boolean], a: Int)
 
-      val test = TestData(Seq(1,2,3),"Hello Ladies + Gentlemen, a signed OAuth request!", None, 5)
+      val test = TestData(Seq((1,2)), Seq(1,2,3),"Hello Ladies + Gentlemen, a signed OAuth request!", None, 5)
       val result = toBodyAsParams(test)
-      result === "a=5&c=Hello Ladies + Gentlemen, a signed OAuth request!&d=1,2,3"
+      result === "a=5&c=Hello Ladies + Gentlemen, a signed OAuth request!&d=1,2,3&e=1.0,2.0"
     }
 
   }


### PR DESCRIPTION
Fixes #169.

Refer to location model from [twitter-hbc](https://github.com/twitter/hbc/blob/master/hbc-core/src/main/java/com/twitter/hbc/core/endpoint/Location.java).

I find the name `Location` a bit ambiguous. So, I followed [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html) API, and name it `GeoBoundingBox`.

Also, from twitter docs, the documentation for locations are: A comma-separated list of longitude,latitude pairs specifying a set of bounding boxes to filter Tweets by.
