### PR TITLE
VideoInfo support

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/entities/Media.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/Media.scala
@@ -11,4 +11,5 @@ final case class Media(display_url: String,
                  source_status_id: Option[Long],
                  source_status_id_str: Option[String],
                  `type`: String,
-                 url: String)
+                 url: String,
+                 video_info: Option[VideoInfo])

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/Variant.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/Variant.scala
@@ -1,3 +1,3 @@
 package com.danielasfregola.twitter4s.entities
 
-final case class Variant(bitrate: Int, content_type: String, url: String)
+final case class Variant(bitrate: Option[Long], content_type: String, url: String)

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/Variant.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/Variant.scala
@@ -1,0 +1,3 @@
+package com.danielasfregola.twitter4s.entities
+
+final case class Variant(bitrate: Int, content_type: String, url: String)

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/VideoInfo.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/VideoInfo.scala
@@ -1,0 +1,3 @@
+package com.danielasfregola.twitter4s.entities
+
+final case class VideoInfo(aspect_ratio: Seq[Int], duration_millis: Option[Long], variants: Seq[Variant])

--- a/src/test/resources/fixtures/rest/favorites/favorites.json
+++ b/src/test/resources/fixtures/rest/favorites/favorites.json
@@ -529,7 +529,8 @@
           "source_status_id": null,
           "source_status_id_str": null,
           "type": "photo",
-          "url": "http://t.co/VKpDq5fBAT"
+          "url": "http://t.co/VKpDq5fBAT",
+          "video_info": null
         }
       ],
       "url": null,
@@ -2251,7 +2252,8 @@
           "source_status_id": null,
           "source_status_id_str": null,
           "type": "photo",
-          "url": "http://t.co/0Zjj5X8IIY"
+          "url": "http://t.co/0Zjj5X8IIY",
+          "video_info": null
         }
       ],
       "url": null,
@@ -2794,7 +2796,8 @@
           "source_status_id": null,
           "source_status_id_str": null,
           "type": "photo",
-          "url": "http://t.co/FhVofVfJ1o"
+          "url": "http://t.co/FhVofVfJ1o",
+          "video_info": null
         }
       ],
       "url": null,
@@ -3360,7 +3363,8 @@
           "source_status_id": null,
           "source_status_id_str": null,
           "type": "photo",
-          "url": "http://t.co/ArQORyug2l"
+          "url": "http://t.co/ArQORyug2l",
+          "video_info": null
         }
       ],
       "url": null,

--- a/src/test/resources/fixtures/rest/statuses/home_timeline.json
+++ b/src/test/resources/fixtures/rest/statuses/home_timeline.json
@@ -366,7 +366,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -502,7 +503,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,
@@ -1420,7 +1422,8 @@
           "source_status_id": null,
           "source_status_id_str": null,
           "type": "photo",
-          "url": "http://t.co/MJZgfsQUsO"
+          "url": "http://t.co/MJZgfsQUsO",
+          "video_info": null
         }
       ],
       "url": null,
@@ -1819,7 +1822,21 @@
           "source_status_id": null,
           "source_status_id_str": null,
           "type": "animated_gif",
-          "url": "http://t.co/zytXLkyndk"
+          "url": "http://t.co/zytXLkyndk",
+          "video_info": {
+            "aspect_ratio": [
+              225,
+              128
+            ],
+            "duration_millis": null,
+            "variants": [
+              {
+                "bitrate": 0,
+                "content_type": "video/mp4",
+                "url": "https://pbs.twimg.com/tweet_video/CQFIC2oWoAAVUNK.mp4"
+              }
+            ]
+          }
         }
       ],
       "url": null,
@@ -2069,7 +2086,8 @@
           "source_status_id": null,
           "source_status_id_str": null,
           "type": "photo",
-          "url": "http://t.co/BDrHG8cpfj"
+          "url": "http://t.co/BDrHG8cpfj",
+          "video_info": null
         }
       ],
       "url": null,
@@ -2309,7 +2327,8 @@
           "source_status_id": null,
           "source_status_id_str": null,
           "type": "photo",
-          "url": "http://t.co/fvGjyot6zu"
+          "url": "http://t.co/fvGjyot6zu",
+          "video_info": null
         }
       ],
       "url": null,
@@ -2424,6 +2443,424 @@
     "withheld_copyright": false,
     "withheld_in_countries": [
     ],
+    "withheld_scope": null,
+    "metadata": null
+  },
+  {
+    "contributors": [],
+    "coordinates": null,
+    "created_at": "Mon Nov 27 15:26:22 +0000 2017",
+    "current_user_retweet": null,
+    "entities": {
+      "hashtags": [
+        {
+          "text": "WrinkleInTime",
+          "indices": [
+            60,
+            74
+          ]
+        }
+      ],
+      "media": [
+        {
+          "display_url": "pic.twitter.com/UBUiRZWiAc",
+          "expanded_url": "https://twitter.com/Disney/status/932418695854305281/video/1",
+          "id": 932389855874621400,
+          "id_str": "932389855874621440",
+          "indices": [
+            84,
+            107
+          ],
+          "media_url": "http://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+          "sizes": {
+            "small": {
+              "h": 283,
+              "resize": "fit",
+              "w": 680
+            },
+            "large": {
+              "h": 853,
+              "resize": "fit",
+              "w": 2048
+            },
+            "thumb": {
+              "h": 150,
+              "resize": "crop",
+              "w": 150
+            },
+            "medium": {
+              "h": 500,
+              "resize": "fit",
+              "w": 1200
+            }
+          },
+          "source_status_id": 932418695854305300,
+          "source_status_id_str": "932418695854305281",
+          "type": "photo",
+          "url": "https://t.co/UBUiRZWiAc",
+          "video_info": null
+        }
+      ],
+      "url": null,
+      "urls": [],
+      "user_mentions": [
+        {
+          "id": 67418441,
+          "id_str": "67418441",
+          "indices": [
+            3,
+            10
+          ],
+          "name": "Disney",
+          "screen_name": "Disney"
+        }
+      ],
+      "description": null
+    },
+    "extended_entities": {
+      "hashtags": [],
+      "media": [
+        {
+          "display_url": "pic.twitter.com/UBUiRZWiAc",
+          "expanded_url": "https://twitter.com/Disney/status/932418695854305281/video/1",
+          "id": 932389855874621400,
+          "id_str": "932389855874621440",
+          "indices": [
+            84,
+            107
+          ],
+          "media_url": "http://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+          "sizes": {
+            "small": {
+              "h": 283,
+              "resize": "fit",
+              "w": 680
+            },
+            "large": {
+              "h": 853,
+              "resize": "fit",
+              "w": 2048
+            },
+            "thumb": {
+              "h": 150,
+              "resize": "crop",
+              "w": 150
+            },
+            "medium": {
+              "h": 500,
+              "resize": "fit",
+              "w": 1200
+            }
+          },
+          "source_status_id": 932418695854305300,
+          "source_status_id_str": "932418695854305281",
+          "type": "video",
+          "url": "https://t.co/UBUiRZWiAc",
+          "video_info": null
+        }
+      ],
+      "url": null,
+      "urls": [],
+      "user_mentions": [],
+      "description": null
+    },
+    "favorite_count": 0,
+    "favorited": false,
+    "filter_level": null,
+    "id": 935167925786480600,
+    "id_str": "935167925786480640",
+    "in_reply_to_screen_name": null,
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "is_quote_status": false,
+    "lang": "en",
+    "place": null,
+    "possibly_sensitive": false,
+    "quoted_status_id": null,
+    "quoted_status_id_str": null,
+    "quoted_status": null,
+    "scopes": {},
+    "retweet_count": 1071,
+    "retweeted": true,
+    "retweeted_status": {
+      "contributors": [],
+      "coordinates": null,
+      "created_at": "Mon Nov 20 01:21:55 +0000 2017",
+      "current_user_retweet": null,
+      "entities": {
+        "hashtags": [
+          {
+            "text": "WrinkleInTime",
+            "indices": [
+              48,
+              62
+            ]
+          }
+        ],
+        "media": [
+          {
+            "display_url": "pic.twitter.com/UBUiRZWiAc",
+            "expanded_url": "https://twitter.com/Disney/status/932418695854305281/video/1",
+            "id": 932389855874621400,
+            "id_str": "932389855874621440",
+            "indices": [
+              72,
+              95
+            ],
+            "media_url": "http://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+            "sizes": {
+              "small": {
+                "h": 283,
+                "resize": "fit",
+                "w": 680
+              },
+              "large": {
+                "h": 853,
+                "resize": "fit",
+                "w": 2048
+              },
+              "thumb": {
+                "h": 150,
+                "resize": "crop",
+                "w": 150
+              },
+              "medium": {
+                "h": 500,
+                "resize": "fit",
+                "w": 1200
+              }
+            },
+            "source_status_id": null,
+            "source_status_id_str": null,
+            "type": "photo",
+            "url": "https://t.co/UBUiRZWiAc",
+            "video_info": null
+          }
+        ],
+        "url": null,
+        "urls": [],
+        "user_mentions": [],
+        "description": null
+      },
+      "extended_entities": {
+        "hashtags": [],
+        "media": [
+          {
+            "display_url": "pic.twitter.com/UBUiRZWiAc",
+            "expanded_url": "https://twitter.com/Disney/status/932418695854305281/video/1",
+            "id": 932389855874621400,
+            "id_str": "932389855874621440",
+            "indices": [
+              72,
+              95
+            ],
+            "media_url": "http://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+            "sizes": {
+              "small": {
+                "h": 283,
+                "resize": "fit",
+                "w": 680
+              },
+              "large": {
+                "h": 853,
+                "resize": "fit",
+                "w": 2048
+              },
+              "thumb": {
+                "h": 150,
+                "resize": "crop",
+                "w": 150
+              },
+              "medium": {
+                "h": 500,
+                "resize": "fit",
+                "w": 1200
+              }
+            },
+            "source_status_id": null,
+            "source_status_id_str": null,
+            "type": "video",
+            "url": "https://t.co/UBUiRZWiAc",
+            "video_info": null
+          }
+        ],
+        "url": null,
+        "urls": [],
+        "user_mentions": [],
+        "description": null
+      },
+      "favorite_count": 2968,
+      "favorited": false,
+      "filter_level": null,
+      "id": 932418695854305300,
+      "id_str": "932418695854305281",
+      "in_reply_to_screen_name": null,
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "is_quote_status": false,
+      "lang": "en",
+      "place": null,
+      "possibly_sensitive": false,
+      "quoted_status_id": null,
+      "quoted_status_id_str": null,
+      "quoted_status": null,
+      "scopes": {},
+      "retweet_count": 1071,
+      "retweeted": true,
+      "retweeted_status": null,
+      "source": "<a href=\"https://studio.twitter.com\" rel=\"nofollow\">Media Studio</a>",
+      "text": "On March 9, be a warrior. The new trailer for A #WrinkleInTime is here. https://t.co/UBUiRZWiAc",
+      "truncated": false,
+      "user": {
+        "blocked_by": false,
+        "blocking": false,
+        "contributors_enabled": false,
+        "created_at": "Thu Aug 20 21:40:59 +0100 2009",
+        "default_profile": false,
+        "default_profile_image": false,
+        "description": "The official Twitter for Disney. Don\u2019t miss a minute of the magic.",
+        "email": null,
+        "entities": {
+          "hashtags": [],
+          "media": [],
+          "url": {
+            "urls": [
+              {
+                "url": "https://t.co/m5jwysh10i",
+                "expanded_url": "http://www.disney.com/",
+                "display_url": "disney.com",
+                "indices": [
+                  0,
+                  23
+                ]
+              }
+            ]
+          },
+          "urls": [],
+          "user_mentions": [],
+          "description": {
+            "urls": []
+          }
+        },
+        "favourites_count": 26,
+        "follow_request_sent": false,
+        "following": false,
+        "followers_count": 5748846,
+        "friends_count": 47,
+        "geo_enabled": false,
+        "has_extended_profile": false,
+        "id": 67418441,
+        "id_str": "67418441",
+        "is_translation_enabled": false,
+        "is_translator": false,
+        "lang": "en",
+        "listed_count": 13388,
+        "location": "",
+        "muting": false,
+        "name": "Disney",
+        "notifications": false,
+        "profile_background_color": "FCFCFC",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/648548100672323585/vVeGkWy3.jpg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/648548100672323585/vVeGkWy3.jpg",
+        "profile_background_tile": false,
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/67418441/1510603344",
+        "profile_image_url": "http://pbs.twimg.com/profile_images/851861956591927296/ArujktQe_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/851861956591927296/ArujktQe_normal.jpg",
+        "profile_link_color": "0E5A82",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "CFE6FF",
+        "profile_text_color": "000000",
+        "profile_use_background_image": false,
+        "protected": false,
+        "screen_name": "Disney",
+        "show_all_inline_media": false,
+        "status": null,
+        "statuses_count": 9518,
+        "time_zone": "Pacific Time (US & Canada)",
+        "url": "https://t.co/m5jwysh10i",
+        "utc_offset": -28800,
+        "verified": true,
+        "withheld_in_countries": null,
+        "withheld_scope": null
+      },
+      "withheld_copyright": false,
+      "withheld_in_countries": [],
+      "withheld_scope": null,
+      "metadata": null
+    },
+    "source": "<a href=\"http://twitter.com\" rel=\"nofollow\">Twitter Web Client</a>",
+    "text": "RT @Disney: On March 9, be a warrior. The new trailer for A #WrinkleInTime is here. https://t.co/UBUiRZWiAc",
+    "truncated": false,
+    "user": {
+      "blocked_by": false,
+      "blocking": false,
+      "contributors_enabled": false,
+      "created_at": "Sat Nov 14 23:21:21 +0000 2009",
+      "default_profile": false,
+      "default_profile_image": false,
+      "description": "",
+      "email": null,
+      "entities": {
+        "hashtags": [],
+        "media": [],
+        "url": null,
+        "urls": [],
+        "user_mentions": [],
+        "description": {
+          "urls": []
+        }
+      },
+      "favourites_count": 8,
+      "follow_request_sent": false,
+      "following": false,
+      "followers_count": 69,
+      "friends_count": 32,
+      "geo_enabled": true,
+      "has_extended_profile": false,
+      "id": 90044663,
+      "id_str": "90044663",
+      "is_translation_enabled": false,
+      "is_translator": false,
+      "lang": "en",
+      "listed_count": 6,
+      "location": "Sao Paulo, Brazil",
+      "muting": false,
+      "name": "Bruno Rossi",
+      "notifications": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme9/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme9/bg.gif",
+      "profile_background_tile": false,
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/90044663/1419423391",
+      "profile_image_url": "http://pbs.twimg.com/profile_images/1154583440/70369_1560623900_8089403_q_normal.jpg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/1154583440/70369_1560623900_8089403_q_normal.jpg",
+      "profile_link_color": "C2BC42",
+      "profile_sidebar_border_color": "101202",
+      "profile_sidebar_fill_color": "DBE6D8",
+      "profile_text_color": "050500",
+      "profile_use_background_image": false,
+      "protected": false,
+      "screen_name": "bob_kkk",
+      "show_all_inline_media": false,
+      "status": null,
+      "statuses_count": 344,
+      "time_zone": "Greenland",
+      "url": null,
+      "utc_offset": -10800,
+      "verified": false,
+      "withheld_in_countries": null,
+      "withheld_scope": null
+    },
+    "withheld_copyright": false,
+    "withheld_in_countries": [],
     "withheld_scope": null,
     "metadata": null
   }

--- a/src/test/resources/fixtures/rest/statuses/home_timeline.json
+++ b/src/test/resources/fixtures/rest/statuses/home_timeline.json
@@ -2558,7 +2558,30 @@
           "source_status_id_str": "932418695854305281",
           "type": "video",
           "url": "https://t.co/UBUiRZWiAc",
-          "video_info": null
+          "video_info": {
+            "aspect_ratio": [
+              320,
+              133
+            ],
+            "duration_millis": 144645,
+            "variants": [
+              {
+                "bitrate": 832000,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/amplify_video/932389855874621440/vid/866x360/4zQMTKefAozX5GAR.mp4"
+              },
+              {
+                "bitrate": 320000,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/amplify_video/932389855874621440/vid/432x180/UsPQIopmeg_Q3RSr.mp4"
+              },
+              {
+                "bitrate": null,
+                "content_type": "application/x-mpegURL",
+                "url": "https://video.twimg.com/amplify_video/932389855874621440/pl/bwoRE3FyURJd8yTl.m3u8"
+              }
+            ]
+          }
         }
       ],
       "url": null,
@@ -2687,7 +2710,30 @@
             "source_status_id_str": null,
             "type": "video",
             "url": "https://t.co/UBUiRZWiAc",
-            "video_info": null
+            "video_info": {
+              "aspect_ratio": [
+                320,
+                133
+              ],
+              "duration_millis": 144645,
+              "variants": [
+                {
+                  "bitrate": 832000,
+                  "content_type": "video/mp4",
+                  "url": "https://video.twimg.com/amplify_video/932389855874621440/vid/866x360/4zQMTKefAozX5GAR.mp4"
+                },
+                {
+                  "bitrate": 320000,
+                  "content_type": "video/mp4",
+                  "url": "https://video.twimg.com/amplify_video/932389855874621440/vid/432x180/UsPQIopmeg_Q3RSr.mp4"
+                },
+                {
+                  "bitrate": null,
+                  "content_type": "application/x-mpegURL",
+                  "url": "https://video.twimg.com/amplify_video/932389855874621440/pl/bwoRE3FyURJd8yTl.m3u8"
+                }
+              ]
+            }
           }
         ],
         "url": null,

--- a/src/test/resources/fixtures/rest/statuses/retweets.json
+++ b/src/test/resources/fixtures/rest/statuses/retweets.json
@@ -114,7 +114,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -250,7 +251,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,
@@ -569,7 +571,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -705,7 +708,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,
@@ -1012,7 +1016,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -1148,7 +1153,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,
@@ -1455,7 +1461,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -1591,7 +1598,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,
@@ -1910,7 +1918,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -2046,7 +2055,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,
@@ -2374,7 +2384,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -2510,7 +2521,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,
@@ -2817,7 +2829,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -2953,7 +2966,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,
@@ -3272,7 +3286,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -3408,7 +3423,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,
@@ -3727,7 +3743,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -3863,7 +3880,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,
@@ -4170,7 +4188,8 @@
           "source_status_id": 648866645855879168,
           "source_status_id_str": "648866645855879168",
           "type": "photo",
-          "url": "http://t.co/hIdTA3v2zE"
+          "url": "http://t.co/hIdTA3v2zE",
+          "video_info": null
         }
       ],
       "url": null,
@@ -4306,7 +4325,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/hIdTA3v2zE"
+            "url": "http://t.co/hIdTA3v2zE",
+            "video_info": null
           }
         ],
         "url": null,

--- a/src/test/resources/fixtures/rest/statuses/retweets_of_me.json
+++ b/src/test/resources/fixtures/rest/statuses/retweets_of_me.json
@@ -976,7 +976,8 @@
           "source_status_id": null,
           "source_status_id_str": null,
           "type": "photo",
-          "url": "http://t.co/XpS3nIcAh1"
+          "url": "http://t.co/XpS3nIcAh1",
+          "video_info": null
         }
       ],
       "url": null,

--- a/src/test/resources/fixtures/rest/statuses/show.json
+++ b/src/test/resources/fixtures/rest/statuses/show.json
@@ -103,7 +103,8 @@
         "source_status_id": null,
         "source_status_id_str": null,
         "type": "photo",
-        "url": "http://t.co/hIdTA3v2zE"
+        "url": "http://t.co/hIdTA3v2zE",
+        "video_info": null
       }
     ],
     "url": null,

--- a/src/test/resources/fixtures/rest/statuses/user_timeline.json
+++ b/src/test/resources/fixtures/rest/statuses/user_timeline.json
@@ -2629,7 +2629,8 @@
           "source_status_id": 634312275638267904,
           "source_status_id_str": "634312275638267904",
           "type": "photo",
-          "url": "http://t.co/6OOYZfryYU"
+          "url": "http://t.co/6OOYZfryYU",
+          "video_info": null
         }
       ],
       "url": null,
@@ -2807,7 +2808,8 @@
             "source_status_id": null,
             "source_status_id_str": null,
             "type": "photo",
-            "url": "http://t.co/6OOYZfryYU"
+            "url": "http://t.co/6OOYZfryYU",
+            "video_info": null
           }
         ],
         "url": null,

--- a/src/test/resources/fixtures/streaming/site/user_envelop_tweet_event.json
+++ b/src/test/resources/fixtures/streaming/site/user_envelop_tweet_event.json
@@ -305,7 +305,8 @@
               "source_status_id": 780422808518086656,
               "source_status_id_str": "780422808518086656",
               "source_user_id": 13458372,
-              "source_user_id_str": "13458372"
+              "source_user_id_str": "13458372",
+              "video_info": null
             }
           ]
         },
@@ -446,7 +447,8 @@
                     "h": 680,
                     "resize": "fit"
                   }
-                }
+                },
+                "video_info": null
               }
             ]
           },

--- a/src/test/resources/fixtures/streaming/site/user_envelop_tweet_event_stringified.json
+++ b/src/test/resources/fixtures/streaming/site/user_envelop_tweet_event_stringified.json
@@ -305,7 +305,8 @@
               "source_status_id": 780422808518086656,
               "source_status_id_str": "780422808518086656",
               "source_user_id": 13458372,
-              "source_user_id_str": "13458372"
+              "source_user_id_str": "13458372",
+              "video_info": null
             }
           ]
         },
@@ -446,7 +447,8 @@
                     "h": 680,
                     "resize": "fit"
                   }
-                }
+                },
+                "video_info": null
               }
             ]
           },

--- a/src/test/resources/fixtures/streaming/user/events.json
+++ b/src/test/resources/fixtures/streaming/user/events.json
@@ -188,7 +188,8 @@
             "source_status_id": 780422808518086656,
             "source_status_id_str": "780422808518086656",
             "source_user_id": 13458372,
-            "source_user_id_str": "13458372"
+            "source_user_id_str": "13458372",
+            "video_info": null
           }
         ]
       },
@@ -329,7 +330,8 @@
                   "h": 680,
                   "resize": "fit"
                 }
-              }
+              },
+              "video_info": null
             }
           ]
         },
@@ -571,7 +573,8 @@
                 "h": 680,
                 "resize": "fit"
               }
-            }
+            },
+            "video_info": null
           }
         ]
       },

--- a/src/test/resources/twitter/rest/statuses/home_timeline.json
+++ b/src/test/resources/twitter/rest/statuses/home_timeline.json
@@ -33,7 +33,9 @@
             }
           ]
         },
-        "description": {"urls": []}
+        "description": {
+          "urls": []
+        }
       },
       "protected": false,
       "followers_count": 258,
@@ -117,7 +119,11 @@
       "location": "Rome, Italy",
       "description": "I build the web. Rails, Erlang, JS \/ Coffee, Android. Made in England.",
       "url": null,
-      "entities": {"description": {"urls": []}},
+      "entities": {
+        "description": {
+          "urls": []
+        }
+      },
       "protected": false,
       "followers_count": 270,
       "friends_count": 247,
@@ -203,7 +209,9 @@
             }
           ]
         },
-        "description": {"urls": []}
+        "description": {
+          "urls": []
+        }
       },
       "protected": false,
       "followers_count": 258,
@@ -277,7 +285,9 @@
               }
             ]
           },
-          "description": {"urls": []}
+          "description": {
+            "urls": []
+          }
         },
         "protected": false,
         "followers_count": 1821,
@@ -562,7 +572,11 @@
       "location": "Bay Area",
       "description": "Senior Director of Global Services for Typesafe. Noted Lambda hater. Author of Effective Akka (O'Reilly), co-author of Reactive Design Patterns (Manning)",
       "url": null,
-      "entities": {"description": {"urls": []}},
+      "entities": {
+        "description": {
+          "urls": []
+        }
+      },
       "protected": false,
       "followers_count": 3854,
       "friends_count": 527,
@@ -634,7 +648,9 @@
               }
             ]
           },
-          "description": {"urls": []}
+          "description": {
+            "urls": []
+          }
         },
         "protected": false,
         "followers_count": 2582,
@@ -799,7 +815,9 @@
             }
           ]
         },
-        "description": {"urls": []}
+        "description": {
+          "urls": []
+        }
       },
       "protected": false,
       "followers_count": 2418,
@@ -873,7 +891,9 @@
               }
             ]
           },
-          "description": {"urls": []}
+          "description": {
+            "urls": []
+          }
         },
         "protected": false,
         "followers_count": 6453,
@@ -1017,7 +1037,9 @@
             }
           ]
         },
-        "description": {"urls": []}
+        "description": {
+          "urls": []
+        }
       },
       "protected": false,
       "followers_count": 58493,
@@ -1349,7 +1371,9 @@
             }
           ]
         },
-        "description": {"urls": []}
+        "description": {
+          "urls": []
+        }
       },
       "protected": false,
       "followers_count": 12952,
@@ -1538,7 +1562,9 @@
             }
           ]
         },
-        "description": {"urls": []}
+        "description": {
+          "urls": []
+        }
       },
       "protected": false,
       "followers_count": 7067,
@@ -1744,7 +1770,9 @@
             }
           ]
         },
-        "description": {"urls": []}
+        "description": {
+          "urls": []
+        }
       },
       "protected": false,
       "followers_count": 9449,
@@ -1903,6 +1931,485 @@
     "retweeted": false,
     "possibly_sensitive": false,
     "possibly_sensitive_appealable": false,
+    "lang": "en"
+  },
+  {
+    "created_at": "Mon Nov 27 15:26:22 +0000 2017",
+    "id": 935167925786480600,
+    "id_str": "935167925786480640",
+    "text": "RT @Disney: On March 9, be a warrior. The new trailer for A #WrinkleInTime is here. https://t.co/UBUiRZWiAc",
+    "truncated": false,
+    "entities": {
+      "hashtags": [
+        {
+          "text": "WrinkleInTime",
+          "indices": [
+            60,
+            74
+          ]
+        }
+      ],
+      "symbols": [],
+      "user_mentions": [
+        {
+          "screen_name": "Disney",
+          "name": "Disney",
+          "id": 67418441,
+          "id_str": "67418441",
+          "indices": [
+            3,
+            10
+          ]
+        }
+      ],
+      "urls": [],
+      "media": [
+        {
+          "id": 932389855874621400,
+          "id_str": "932389855874621440",
+          "indices": [
+            84,
+            107
+          ],
+          "media_url": "http://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+          "url": "https://t.co/UBUiRZWiAc",
+          "display_url": "pic.twitter.com/UBUiRZWiAc",
+          "expanded_url": "https://twitter.com/Disney/status/932418695854305281/video/1",
+          "type": "photo",
+          "sizes": {
+            "small": {
+              "w": 680,
+              "h": 283,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 2048,
+              "h": 853,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "medium": {
+              "w": 1200,
+              "h": 500,
+              "resize": "fit"
+            }
+          },
+          "source_status_id": 932418695854305300,
+          "source_status_id_str": "932418695854305281",
+          "source_user_id": 67418441,
+          "source_user_id_str": "67418441"
+        }
+      ]
+    },
+    "extended_entities": {
+      "media": [
+        {
+          "id": 932389855874621400,
+          "id_str": "932389855874621440",
+          "indices": [
+            84,
+            107
+          ],
+          "media_url": "http://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+          "media_url_https": "https://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+          "url": "https://t.co/UBUiRZWiAc",
+          "display_url": "pic.twitter.com/UBUiRZWiAc",
+          "expanded_url": "https://twitter.com/Disney/status/932418695854305281/video/1",
+          "type": "video",
+          "sizes": {
+            "small": {
+              "w": 680,
+              "h": 283,
+              "resize": "fit"
+            },
+            "large": {
+              "w": 2048,
+              "h": 853,
+              "resize": "fit"
+            },
+            "thumb": {
+              "w": 150,
+              "h": 150,
+              "resize": "crop"
+            },
+            "medium": {
+              "w": 1200,
+              "h": 500,
+              "resize": "fit"
+            }
+          },
+          "source_status_id": 932418695854305300,
+          "source_status_id_str": "932418695854305281",
+          "source_user_id": 67418441,
+          "source_user_id_str": "67418441",
+          "video_info": {
+            "aspect_ratio": [
+              320,
+              133
+            ],
+            "duration_millis": 144645,
+            "variants": [
+              {
+                "bitrate": 832000,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/amplify_video/932389855874621440/vid/866x360/4zQMTKefAozX5GAR.mp4"
+              },
+              {
+                "bitrate": 320000,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/amplify_video/932389855874621440/vid/432x180/UsPQIopmeg_Q3RSr.mp4"
+              },
+              {
+                "content_type": "application/x-mpegURL",
+                "url": "https://video.twimg.com/amplify_video/932389855874621440/pl/bwoRE3FyURJd8yTl.m3u8"
+              }
+            ]
+          },
+          "additional_media_info": {
+            "title": "",
+            "description": "",
+            "embeddable": true,
+            "monetizable": false,
+            "source_user": {
+              "id": 67418441,
+              "id_str": "67418441",
+              "name": "Disney",
+              "screen_name": "Disney",
+              "location": "",
+              "description": "The official Twitter for Disney. Don’t miss a minute of the magic.",
+              "url": "https://t.co/m5jwysh10i",
+              "entities": {
+                "url": {
+                  "urls": [
+                    {
+                      "url": "https://t.co/m5jwysh10i",
+                      "expanded_url": "http://www.disney.com/",
+                      "display_url": "disney.com",
+                      "indices": [
+                        0,
+                        23
+                      ]
+                    }
+                  ]
+                },
+                "description": {
+                  "urls": []
+                }
+              },
+              "protected": false,
+              "followers_count": 5748846,
+              "friends_count": 47,
+              "listed_count": 13388,
+              "created_at": "Thu Aug 20 20:40:59 +0000 2009",
+              "favourites_count": 26,
+              "utc_offset": -28800,
+              "time_zone": "Pacific Time (US & Canada)",
+              "geo_enabled": false,
+              "verified": true,
+              "statuses_count": 9518,
+              "lang": "en",
+              "contributors_enabled": false,
+              "is_translator": false,
+              "is_translation_enabled": false,
+              "profile_background_color": "FCFCFC",
+              "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/648548100672323585/vVeGkWy3.jpg",
+              "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/648548100672323585/vVeGkWy3.jpg",
+              "profile_background_tile": false,
+              "profile_image_url": "http://pbs.twimg.com/profile_images/851861956591927296/ArujktQe_normal.jpg",
+              "profile_image_url_https": "https://pbs.twimg.com/profile_images/851861956591927296/ArujktQe_normal.jpg",
+              "profile_banner_url": "https://pbs.twimg.com/profile_banners/67418441/1510603344",
+              "profile_link_color": "0E5A82",
+              "profile_sidebar_border_color": "FFFFFF",
+              "profile_sidebar_fill_color": "CFE6FF",
+              "profile_text_color": "000000",
+              "profile_use_background_image": false,
+              "has_extended_profile": false,
+              "default_profile": false,
+              "default_profile_image": false,
+              "following": false,
+              "follow_request_sent": false,
+              "notifications": false,
+              "translator_type": "none"
+            }
+          }
+        }
+      ]
+    },
+    "source": "<a href=\"http://twitter.com\" rel=\"nofollow\">Twitter Web Client</a>",
+    "in_reply_to_status_id": null,
+    "in_reply_to_status_id_str": null,
+    "in_reply_to_user_id": null,
+    "in_reply_to_user_id_str": null,
+    "in_reply_to_screen_name": null,
+    "user": {
+      "id": 90044663,
+      "id_str": "90044663",
+      "name": "Bruno Rossi",
+      "screen_name": "bob_kkk",
+      "location": "Sao Paulo, Brazil",
+      "description": "",
+      "url": null,
+      "entities": {
+        "description": {
+          "urls": []
+        }
+      },
+      "protected": false,
+      "followers_count": 69,
+      "friends_count": 32,
+      "listed_count": 6,
+      "created_at": "Sat Nov 14 23:21:21 +0000 2009",
+      "favourites_count": 8,
+      "utc_offset": -10800,
+      "time_zone": "Greenland",
+      "geo_enabled": true,
+      "verified": false,
+      "statuses_count": 344,
+      "lang": "en",
+      "contributors_enabled": false,
+      "is_translator": false,
+      "is_translation_enabled": false,
+      "profile_background_color": "000000",
+      "profile_background_image_url": "http://abs.twimg.com/images/themes/theme9/bg.gif",
+      "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme9/bg.gif",
+      "profile_background_tile": false,
+      "profile_image_url": "http://pbs.twimg.com/profile_images/1154583440/70369_1560623900_8089403_q_normal.jpg",
+      "profile_image_url_https": "https://pbs.twimg.com/profile_images/1154583440/70369_1560623900_8089403_q_normal.jpg",
+      "profile_banner_url": "https://pbs.twimg.com/profile_banners/90044663/1419423391",
+      "profile_link_color": "C2BC42",
+      "profile_sidebar_border_color": "101202",
+      "profile_sidebar_fill_color": "DBE6D8",
+      "profile_text_color": "050500",
+      "profile_use_background_image": false,
+      "has_extended_profile": false,
+      "default_profile": false,
+      "default_profile_image": false,
+      "following": false,
+      "follow_request_sent": false,
+      "notifications": false,
+      "translator_type": "none"
+    },
+    "geo": null,
+    "coordinates": null,
+    "place": null,
+    "contributors": null,
+    "retweeted_status": {
+      "created_at": "Mon Nov 20 01:21:55 +0000 2017",
+      "id": 932418695854305300,
+      "id_str": "932418695854305281",
+      "text": "On March 9, be a warrior. The new trailer for A #WrinkleInTime is here. https://t.co/UBUiRZWiAc",
+      "truncated": false,
+      "entities": {
+        "hashtags": [
+          {
+            "text": "WrinkleInTime",
+            "indices": [
+              48,
+              62
+            ]
+          }
+        ],
+        "symbols": [],
+        "user_mentions": [],
+        "urls": [],
+        "media": [
+          {
+            "id": 932389855874621400,
+            "id_str": "932389855874621440",
+            "indices": [
+              72,
+              95
+            ],
+            "media_url": "http://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+            "url": "https://t.co/UBUiRZWiAc",
+            "display_url": "pic.twitter.com/UBUiRZWiAc",
+            "expanded_url": "https://twitter.com/Disney/status/932418695854305281/video/1",
+            "type": "photo",
+            "sizes": {
+              "small": {
+                "w": 680,
+                "h": 283,
+                "resize": "fit"
+              },
+              "large": {
+                "w": 2048,
+                "h": 853,
+                "resize": "fit"
+              },
+              "thumb": {
+                "w": 150,
+                "h": 150,
+                "resize": "crop"
+              },
+              "medium": {
+                "w": 1200,
+                "h": 500,
+                "resize": "fit"
+              }
+            }
+          }
+        ]
+      },
+      "extended_entities": {
+        "media": [
+          {
+            "id": 932389855874621400,
+            "id_str": "932389855874621440",
+            "indices": [
+              72,
+              95
+            ],
+            "media_url": "http://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+            "media_url_https": "https://pbs.twimg.com/media/DPCGOwRV4AA0oya.jpg",
+            "url": "https://t.co/UBUiRZWiAc",
+            "display_url": "pic.twitter.com/UBUiRZWiAc",
+            "expanded_url": "https://twitter.com/Disney/status/932418695854305281/video/1",
+            "type": "video",
+            "sizes": {
+              "small": {
+                "w": 680,
+                "h": 283,
+                "resize": "fit"
+              },
+              "large": {
+                "w": 2048,
+                "h": 853,
+                "resize": "fit"
+              },
+              "thumb": {
+                "w": 150,
+                "h": 150,
+                "resize": "crop"
+              },
+              "medium": {
+                "w": 1200,
+                "h": 500,
+                "resize": "fit"
+              }
+            },
+            "video_info": {
+              "aspect_ratio": [
+                320,
+                133
+              ],
+              "duration_millis": 144645,
+              "variants": [
+                {
+                  "bitrate": 832000,
+                  "content_type": "video/mp4",
+                  "url": "https://video.twimg.com/amplify_video/932389855874621440/vid/866x360/4zQMTKefAozX5GAR.mp4"
+                },
+                {
+                  "bitrate": 320000,
+                  "content_type": "video/mp4",
+                  "url": "https://video.twimg.com/amplify_video/932389855874621440/vid/432x180/UsPQIopmeg_Q3RSr.mp4"
+                },
+                {
+                  "content_type": "application/x-mpegURL",
+                  "url": "https://video.twimg.com/amplify_video/932389855874621440/pl/bwoRE3FyURJd8yTl.m3u8"
+                }
+              ]
+            },
+            "additional_media_info": {
+              "title": "",
+              "description": "",
+              "embeddable": true,
+              "monetizable": false
+            }
+          }
+        ]
+      },
+      "source": "<a href=\"https://studio.twitter.com\" rel=\"nofollow\">Media Studio</a>",
+      "in_reply_to_status_id": null,
+      "in_reply_to_status_id_str": null,
+      "in_reply_to_user_id": null,
+      "in_reply_to_user_id_str": null,
+      "in_reply_to_screen_name": null,
+      "user": {
+        "id": 67418441,
+        "id_str": "67418441",
+        "name": "Disney",
+        "screen_name": "Disney",
+        "location": "",
+        "description": "The official Twitter for Disney. Don’t miss a minute of the magic.",
+        "url": "https://t.co/m5jwysh10i",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "https://t.co/m5jwysh10i",
+                "expanded_url": "http://www.disney.com/",
+                "display_url": "disney.com",
+                "indices": [
+                  0,
+                  23
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 5748846,
+        "friends_count": 47,
+        "listed_count": 13388,
+        "created_at": "Thu Aug 20 20:40:59 +0000 2009",
+        "favourites_count": 26,
+        "utc_offset": -28800,
+        "time_zone": "Pacific Time (US & Canada)",
+        "geo_enabled": false,
+        "verified": true,
+        "statuses_count": 9518,
+        "lang": "en",
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "FCFCFC",
+        "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/648548100672323585/vVeGkWy3.jpg",
+        "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/648548100672323585/vVeGkWy3.jpg",
+        "profile_background_tile": false,
+        "profile_image_url": "http://pbs.twimg.com/profile_images/851861956591927296/ArujktQe_normal.jpg",
+        "profile_image_url_https": "https://pbs.twimg.com/profile_images/851861956591927296/ArujktQe_normal.jpg",
+        "profile_banner_url": "https://pbs.twimg.com/profile_banners/67418441/1510603344",
+        "profile_link_color": "0E5A82",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "CFE6FF",
+        "profile_text_color": "000000",
+        "profile_use_background_image": false,
+        "has_extended_profile": false,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false,
+        "translator_type": "none"
+      },
+      "geo": null,
+      "coordinates": null,
+      "place": null,
+      "contributors": null,
+      "is_quote_status": false,
+      "retweet_count": 1071,
+      "favorite_count": 2968,
+      "favorited": false,
+      "retweeted": true,
+      "possibly_sensitive": false,
+      "lang": "en"
+    },
+    "is_quote_status": false,
+    "retweet_count": 1071,
+    "favorite_count": 0,
+    "favorited": false,
+    "retweeted": true,
+    "possibly_sensitive": false,
     "lang": "en"
   }
 ]


### PR DESCRIPTION
Created class for VideoInfo, Variant and included attribute in the Media for issue #181. Fixtures files updated to support the new field and one new json included in home_timeline.json to test the new parser.

This PR is based in the tag v5.2.