### PR TITLE
Make TwitterRestClient constructor accessible to allow app-only-auth hack

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/TwitterRestClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/TwitterRestClient.scala
@@ -27,8 +27,8 @@ import com.danielasfregola.twitter4s.util.SystemShutdown
 
 /** Represents the functionalities offered by the Twitter REST API
   */
-class TwitterRestClient private (val consumerToken: ConsumerToken, val accessToken: AccessToken)(
-    implicit _system: ActorSystem = ActorSystem("twitter4s-rest"))
+class TwitterRestClient(val consumerToken: ConsumerToken, val accessToken: AccessToken)(implicit _system: ActorSystem =
+                                                                                          ActorSystem("twitter4s-rest"))
     extends RestClients
     with SystemShutdown {
 


### PR DESCRIPTION
Following on from https://github.com/DanielaSfregola/twitter4s/issues/237#issuecomment-474426923 this is the smallest change required to get the constructor-overriding hack in this gist to work:

https://gist.github.com/rtyley/dc341992a6104f4b499834fd2d10dfad