### PR TITLE
Bump akka and akka-http version to latest version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@ resolvers ++= Seq(
 libraryDependencies ++= {
 
   val Typesafe = "1.3.2"
-  val Akka = "2.5.8"
-  val AkkaHttp = "10.0.10"
+  val Akka = "2.5.22"
+  val AkkaHttp = "10.1.8"
   val AkkaHttpJson4s = "1.18.1"
   val Json4s = "3.5.3"
   val Specs2 = "4.0.1"

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/OAuthClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/OAuthClient.scala
@@ -44,7 +44,7 @@ private[twitter4s] trait OAuthClient extends CommonClient with RequestBuilding {
 
     def apply(uri: String, content: Product): HttpRequest = {
       val data = toBodyAsEncodedParams(content)
-      val contentType = ContentType(MediaTypes.`application/x-www-form-urlencoded`, HttpCharsets.`UTF-8`)
+      val contentType = ContentType(MediaTypes.`application/x-www-form-urlencoded`)
       apply(uri, data, contentType)
     }
 

--- a/src/test/scala/com/danielasfregola/twitter4s/helpers/Spec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/helpers/Spec.scala
@@ -8,7 +8,7 @@ import org.specs2.mutable.SpecificationLike
 
 trait Spec extends SpecificationLike with UriHelpers {
 
-  val `application/x-www-form-urlencoded` = MediaTypes.`application/x-www-form-urlencoded` withCharset HttpCharsets.`UTF-8`
+  val `application/x-www-form-urlencoded` = MediaTypes.`application/x-www-form-urlencoded`
   val `text/plain` = MediaTypes.`text/plain` withCharset HttpCharsets.`UTF-8`
 
   trait SpecContext extends FixturesSupport with AwaitableFuture with Scope {

--- a/src/test/scala/com/danielasfregola/twitter4s/http/oauth/OAuth1ProviderSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/oauth/OAuth1ProviderSpec.scala
@@ -1,8 +1,8 @@
 package com.danielasfregola.twitter4s.http
 package oauth
 
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{HttpCharsets, _}
 import com.danielasfregola.twitter4s.entities.{AccessToken, ConsumerToken}
 import com.danielasfregola.twitter4s.helpers.{AwaitableFuture, TestActorSystem, TestExecutionContext}
 import org.specs2.matcher.Scope
@@ -14,7 +14,7 @@ class OAuth1ProviderSpec extends TestActorSystem with SpecificationLike with Awa
 
   val request = {
     val uri = Uri("https://api.twitter.com/1/statuses/update.json?include_entities=true")
-    val contentType = ContentType(MediaTypes.`application/x-www-form-urlencoded`, HttpCharsets.`UTF-8`)
+    val contentType = ContentType(MediaTypes.`application/x-www-form-urlencoded`)
     val entity = HttpEntity("status=Hello+Ladies+%2B+Gentlemen%2C+a+signed+OAuth+request%21")
     HttpRequest(method = HttpMethods.POST, uri = uri, entity = entity.withContentType(contentType))
   }


### PR DESCRIPTION
I tried using twitter4s with latest akka and akka-http but twitter4s kept failing with the following error:

```
Exception in thread "main" java.lang.NoSuchMethodError: akka.http.scaladsl.model.MediaTypes$.application$divx$minuswww$minusform$minusurlencoded()Lakka/http/scaladsl/model/MediaType$WithOpenCharset;
	at com.danielasfregola.twitter4s.http.clients.OAuthClient$OAuthRequestBuilder.apply(OAuthClient.scala:47)
	at com.danielasfregola.twitter4s.http.clients.streaming.statuses.TwitterStatusClient.filterStatuses(TwitterStatusClient.scala:64)
	at com.danielasfregola.twitter4s.http.clients.streaming.statuses.TwitterStatusClient.filterStatuses$(TwitterStatusClient.scala:51)
	at com.danielasfregola.twitter4s.TwitterStreamingClient.filterStatuses(TwitterStreamingClient.scala:14)
```

akka-http has removed the charset parameter from '`application/x-www-form-urlencoded`' in the latest version, so I've bumped akka to the latest version and made sure all tests pass