### PR TITLE
Add Scala 2.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 scala:
-  - 2.12.4
+  - 2.13.0
+  - 2.12.10
   - 2.11.12
 
 # whitelist

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ version := "6.2-SNAPSHOT"
 scalaVersion := "2.12.4"
 
 resolvers ++= Seq(
-  "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/",
+  Resolver.sonatypeRepo("releases"),
   Resolver.jcenterRepo
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ enablePlugins(GhpagesPlugin, SiteScaladocPlugin)
 name := "twitter4s"
 version := "6.2-SNAPSHOT"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.13.0"
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
@@ -53,7 +53,7 @@ lazy val standardSettings = Seq(
     ScmInfo(url("https://github.com/DanielaSfregola/twitter4s"),
             "scm:git:git@github.com:DanielaSfregola/twitter4s.git")),
   apiURL := Some(url("http://DanielaSfregola.github.io/twitter4s/latest/api/")),
-  crossScalaVersions := Seq("2.12.4", "2.11.12"),
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.10", "2.11.12"),
   pomExtra := (
     <developers>
     <developer>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
+resolvers += "jgit-repo" at "https://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/Client.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/Client.scala
@@ -18,7 +18,7 @@ trait Client extends OAuthClient {
   protected def sendAndReceive[T](request: HttpRequest, f: HttpResponse => Future[T])(
       implicit system: ActorSystem,
       materializer: Materializer): Future[T] = {
-    implicit val _ = request
+    implicit val r: HttpRequest = request
     val requestStartTime = System.currentTimeMillis
 
     if (withLogRequest) logRequest

--- a/src/main/scala/com/danielasfregola/twitter4s/http/marshalling/BodyEncoder.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/marshalling/BodyEncoder.scala
@@ -42,6 +42,6 @@ trait BodyEncoder {
 
   // TODO - improve performance with Macros?
   private def asMap(cc: Product): Map[String, Any] =
-    cc.getClass.getDeclaredFields.map(_.getName).zip(cc.productIterator.to).toMap
+    cc.getClass.getDeclaredFields.map(_.getName).zip(cc.productIterator.toSeq).toMap
 
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/oauth/OAuth1Provider.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/oauth/OAuth1Provider.scala
@@ -30,7 +30,7 @@ private[twitter4s] class OAuth1Provider(consumerToken: ConsumerToken, accessToke
     val params = basicOAuth2Params(callback)
     for {
       signature <- oauth1Signature(params)
-    } yield (params + signature).mapValues(_.urlEncoded)
+    } yield (params + signature).mapValues(_.urlEncoded).toMap
   }
 
   def oauth1Signature(oauth2Params: Map[String, String])(implicit request: HttpRequest, materializer: Materializer) = {
@@ -67,7 +67,7 @@ private[twitter4s] class OAuth1Provider(consumerToken: ConsumerToken, accessToke
       val method = request.method.name.urlEncoded
       val baseUrl = request.uri.endpoint.urlEncoded
       val oauthParams = oauth2Params.map {
-        case (k, v) =>
+        case (k: String, v: String) =>
           if (k == "oauth_callback") k -> v.urlEncoded
           else k -> v
       }
@@ -90,7 +90,8 @@ private[twitter4s] class OAuth1Provider(consumerToken: ConsumerToken, accessToke
     }
   }
 
-  def queryParams(implicit request: HttpRequest) = request.uri.query().toMap.mapValues(_.urlEncoded)
+  def queryParams(implicit request: HttpRequest): Map[String, String] =
+    request.uri.query().toMap.mapValues(_.urlEncoded).toMap
 
   private def encodeParams(params: Map[String, String]) =
     params.keySet.toList.sorted

--- a/src/main/scala/com/danielasfregola/twitter4s/http/serializers/StreamingMessageFormats.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/serializers/StreamingMessageFormats.scala
@@ -21,7 +21,7 @@ private[twitter4s] object StreamingMessageFormats extends FormatsComposer {
   private val tweetUnmarshaller = FieldSerializer[Tweet](deserializer = FieldSerializer.renameFrom("full_text", "text"))
 
   private def withCustomUnmarshaller[T <: StreamingMessage: Manifest](json: JValue, formatter: Formats): Option[T] = {
-    implicit val _: Formats = formatter
+    implicit val formats: Formats = formatter
     Extraction.extractOpt[T](json)
   }
 


### PR DESCRIPTION
This PR updates `twitter4s` to compile with Scala 2.13 by default, while still cross-compiling to Scala 2.12 & 2.11.

Although Scala 2.13.**1** has been released, this change sticks with 2.13.**0**, as `scoverage` has not yet released an update compatible with that latest version (see scoverage/sbt-scoverage#295, scoverage/sbt-scoverage#299) -  the current latest release of `scoverage`, 1.6.0, only works with  Scala 2.13.0.

Migration issues addressed with this update:

* Underscore (`_`) is no longer a valid identifer for `val`s
* `Map.mapValues()` now returns a `MapView` rather than a `Map`
* `.to` can no longer infer what resulting collection type you want
