### PR TITLE
Fix absent refresh_url on popular result_type search

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/entities/TweetSearch.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/TweetSearch.scala
@@ -7,7 +7,7 @@ final case class SearchMetadata(completed_in: Double,
                                 max_id_str: String,
                                 next_results: Option[String],
                                 query: String,
-                                refresh_url: String,
+                                refresh_url: Option[String],
                                 count: Int,
                                 since_id: Long,
                                 since_id_str: String)


### PR DESCRIPTION
Twitter does not include the `refresh_url` when searching popular tweets. 

The search metadata for `https://api.twitter.com/1.1/search/tweets.json?q=lang:en&count=100&result_type=popular` looks as follows:
```json
    "search_metadata": {
        "completed_in": 0.045,
        "max_id": 0,
        "max_id_str": "0",
        "next_results": "?max_id=1275972098247270401&q=lang%3Aen&count=100&include_entities=1&result_type=popular",
        "query": "lang%3Aen",
        "count": 100,
        "since_id": 0,
        "since_id_str": "0"
    }
```

My proposed solution is to make the refresh_url optional. This mitigates deserialization errors.
 