### PR TITLE
Support media_category for chunked media uploads

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/media/TwitterMediaClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/media/TwitterMediaClient.scala
@@ -107,7 +107,15 @@ trait TwitterMediaClient {
 
   private def initMedia(size: Long, media_type: String, additional_owners: Seq[Long]): Future[MediaDetails] = {
     import restClient._
-    val parameters = MediaInitParameters(size, media_type, Some(additional_owners.mkString(",")))
+    val media_category = media_type.toLowerCase match {
+      case mediaType if mediaType.startsWith("image/gif") => Some("tweet_gif")
+      case mediaType if mediaType.startsWith("image/")    => Some("tweet_image")
+      case mediaType if mediaType.startsWith("video/")    => Some("tweet_video")
+      case _                                              => None
+    }
+
+    val parameters =
+      MediaInitParameters(size, media_type, media_category, Some(additional_owners.mkString(",")))
     Post(s"$mediaUrl/upload.json", parameters).respondAs[MediaDetails]
   }
 

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/media/parameters/MediaInitParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/media/parameters/MediaInitParameters.scala
@@ -4,6 +4,7 @@ import com.danielasfregola.twitter4s.http.marshalling.Parameters
 
 private[twitter4s] final case class MediaInitParameters(total_bytes: Long,
                                                         media_type: String,
+                                                        media_category: Option[String],
                                                         additional_owners: Option[String],
                                                         command: String = "INIT")
     extends Parameters

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/media/TwitterMediaClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/media/TwitterMediaClientSpec.scala
@@ -22,7 +22,8 @@ class TwitterMediaClientSpec extends ClientSpec {
           .expectRequest { request =>
             request.method === HttpMethods.POST
             request.uri.endpoint === "https://upload.twitter.com/1.1/media/upload.json"
-            request.uri.rawQueryString === Some("command=INIT&media_type=image%2Fpng&total_bytes=22689")
+            request.uri.rawQueryString === Some(
+              "command=INIT&media_category=TweetImage&media_type=image%2Fpng&total_bytes=22689")
           }
           .respondWith(initMediaResponse)
           .expectRequest { request =>


### PR DESCRIPTION
### Overview
Adds support for the `media_category` field on chunked uploads, which allows
* Up to 15 MB animated GIFs to be uploaded 
* Up to 512 MB videos to be uploaded (according to documentation; I verified I could upload a 42 MB and not the 512 MB limit, so this assumes twitter documentation is accurate)
* Videos to be uploaded longer than 30 seconds (not specifying `media_category: 'tweet_video'` and uploading a long video gives an error saying the max duration is 30 seconds)

### Tests (Uploaded and posted to twitter)
* Images
  * Verified 4 mb image (1 chunk)
  * Failed to upload 7.8 mb image (expected; documented limit is 5 mb)
* GIF
  * Verified 4.7 mb gif (1 chunk)
  * Verified 6.6 mb gif (2 chunks)
* Video
  * Verified 1 mb video (1 chunk)
  * Verified 10.9 mb video (3 chunks)
  * Verified 42 mb video (9 chunks)
