### PR TITLE
Make some media upload/status fields optional

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/entities/MediaDetails.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/MediaDetails.scala
@@ -2,7 +2,7 @@ package com.danielasfregola.twitter4s.entities
 
 final case class MediaDetails(media_id: Long,
                               media_id_string: String,
-                              expires_after_secs: Int,
+                              expires_after_secs: Option[Int] = None,
                               size: Option[Long] = None,
                               image: Option[Image] = None,
                               video: Option[Video] = None,
@@ -11,6 +11,6 @@ final case class MediaDetails(media_id: Long,
 final case class ProcessingInfo(state: String,
                                 progress_percent: Long,
                                 check_after_secs: Option[Int],
-                                error: ProcessingError)
+                                error: Option[ProcessingError])
 
 final case class ProcessingError(code: Int, name: String, message: String)


### PR DESCRIPTION
### Overview
Makes a few media upload/status fields optional since they sometimes aren't returned by twitter.
