### PR TITLE
Make `progress_percent` optional

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/entities/MediaDetails.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/MediaDetails.scala
@@ -9,7 +9,7 @@ final case class MediaDetails(media_id: Long,
                               processing_info: Option[ProcessingInfo] = None)
 
 final case class ProcessingInfo(state: String,
-                                progress_percent: Long,
+                                progress_percent: Option[Long],
                                 check_after_secs: Option[Int],
                                 error: Option[ProcessingError])
 


### PR DESCRIPTION
I discovered that this field wasn't returned when `state == "pending"` so `processing_info` wouldn't get deserialized. I did not make `state` optional since the twitter docs seem to indicate that if `processing_info` exists, then so does `state`, but I could be convinced to make it optional anyways.