### PR TITLE
Support for full-archive / academic research track endpoints

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ enablePlugins(GhpagesPlugin, SiteScaladocPlugin)
 name := "twitter4s"
 version := "7.2-SNAPSHOT"
 
-scalaVersion := "2.13.4"
+scalaVersion := "2.12.13"
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
@@ -17,7 +17,7 @@ libraryDependencies ++= {
   val Akka = "2.6.12"
   val AkkaHttp = "10.2.3"
   val AkkaHttpJson4s = "1.35.3"
-  val Json4s = "3.7.0-M8"
+  val Json4s = "3.6.6"
   val Specs2 = "4.10.6"
   val ScalaLogging = "3.9.2"
   val RandomDataGenerator = "2.8"
@@ -56,12 +56,12 @@ lazy val standardSettings = Seq(
   crossScalaVersions := Seq(scalaVersion.value, "2.12.10"),
   pomExtra := (
     <developers>
-    <developer>
-      <id>DanielaSfregola</id>
-      <name>Daniela Sfregola</name>
-      <url>http://danielasfregola.com/</url>
-    </developer>
-  </developers>
+      <developer>
+        <id>DanielaSfregola</id>
+        <name>Daniela Sfregola</name>
+        <url>http://danielasfregola.com/</url>
+      </developer>
+    </developers>
   ),
   publishMavenStyle := true,
   publishTo := {

--- a/src/main/scala/com/danielasfregola/twitter4s/TwitterAuthenticationClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/TwitterAuthenticationClient.scala
@@ -25,7 +25,7 @@ trait TwitterAuthClients extends TwitterOAuthClient
 object TwitterAuthenticationClient {
 
   def apply(): TwitterAuthenticationClient = {
-    val consumerToken = ConsumerToken(key = consumerTokenKey, secret = consumerTokenSecret)
+    val consumerToken = ConsumerToken(key = consumerTokenKey.get, secret = consumerTokenSecret.get)
     apply(consumerToken)
   }
 
@@ -33,7 +33,7 @@ object TwitterAuthenticationClient {
     new TwitterAuthenticationClient(consumerToken)
 
   def withActorSystem(system: ActorSystem): TwitterAuthenticationClient = {
-    val consumerToken = ConsumerToken(key = consumerTokenKey, secret = consumerTokenSecret)
+    val consumerToken = ConsumerToken(key = consumerTokenKey.get, secret = consumerTokenSecret.get)
     withActorSystem(consumerToken)(system)
   }
 

--- a/src/main/scala/com/danielasfregola/twitter4s/TwitterRestClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/TwitterRestClient.scala
@@ -79,6 +79,10 @@ object TwitterRestClient {
         val accessToken = AccessToken(key = accessTokenKey.get, secret = accessTokenSecret.get)
         apply(consumerToken, accessToken, bearerToken = bearerToken.get)
       }
+      case _ => {
+        // Uh, we somehow have no authmode?
+        throw new RuntimeException("TwitterRestClient: No authentication mode is defined")
+      }
     }
   }
 

--- a/src/main/scala/com/danielasfregola/twitter4s/TwitterStreamingClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/TwitterStreamingClient.scala
@@ -27,8 +27,8 @@ trait StreamingClients extends TwitterStatusClient with TwitterUserClient with T
 object TwitterStreamingClient {
 
   def apply(): TwitterStreamingClient = {
-    val consumerToken = ConsumerToken(key = consumerTokenKey, secret = consumerTokenSecret)
-    val accessToken = AccessToken(key = accessTokenKey, secret = accessTokenSecret)
+    val consumerToken = ConsumerToken(key = consumerTokenKey.get, secret = consumerTokenSecret.get)
+    val accessToken = AccessToken(key = accessTokenKey.get, secret = accessTokenSecret.get)
     apply(consumerToken, accessToken)
   }
 
@@ -36,8 +36,8 @@ object TwitterStreamingClient {
     new TwitterStreamingClient(consumerToken, accessToken)
 
   def withActorSystem(system: ActorSystem): TwitterStreamingClient = {
-    val consumerToken = ConsumerToken(key = consumerTokenKey, secret = consumerTokenSecret)
-    val accessToken = AccessToken(key = accessTokenKey, secret = accessTokenSecret)
+    val consumerToken = ConsumerToken(key = consumerTokenKey.get, secret = consumerTokenSecret.get)
+    val accessToken = AccessToken(key = accessTokenKey.get, secret = accessTokenSecret.get)
     withActorSystem(consumerToken, accessToken)(system)
   }
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/TweetSearch.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/TweetSearch.scala
@@ -13,3 +13,7 @@ final case class SearchMetadata(completed_in: Double,
                                 since_id_str: String)
 
 final case class StatusMetadata(iso_language_code: String, result_type: String)
+
+final case class StatusFullSearch(statuses: List[Tweet], meta: FullSearchMetadata)
+
+final case class FullSearchMetadata(newest_id: String, oldest_id: String, result_count: Int, next_token: Option[String])

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/TweetSearch.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/TweetSearch.scala
@@ -14,6 +14,13 @@ final case class SearchMetadata(completed_in: Double,
 
 final case class StatusMetadata(iso_language_code: String, result_type: String)
 
-final case class StatusFullSearch(statuses: List[Tweet], meta: FullSearchMetadata)
+final case class StatusFullSearch(data: List[MinimalTweet], meta: FullSearchMetadata)
 
-final case class FullSearchMetadata(newest_id: String, oldest_id: String, result_count: Int, next_token: Option[String])
+final case class FullSearchMetadata(newest_id: Option[String],
+                                    oldest_id: Option[String],
+                                    result_count: Int,
+                                    next_token: Option[String])
+
+// TODO: break this out into entities?
+// Full archive search only returns this when there are tweets returned
+final case class MinimalTweet(id: String, text: String)

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/TweetSearch.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/TweetSearch.scala
@@ -23,4 +23,4 @@ final case class FullSearchMetadata(newest_id: Option[String],
 
 // TODO: break this out into entities?
 // Full archive search only returns this when there are tweets returned
-final case class MinimalTweet(id: String, text: String)
+final case class MinimalTweet(id: String, text: String, author_id: Option[String])

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/enums/OAuthMode.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/enums/OAuthMode.scala
@@ -1,9 +1,0 @@
-package com.danielasfregola.twitter4s.entities.enums
-
-object OAuthMode extends Enumeration {
-  type OAuthMode = Value
-
-  val UseOAuth1 = Value(1)
-  val UseOAuthBearerToken = Value(2)
-  val MixedAuth = Value(3)
-}

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/enums/OAuthMode.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/enums/OAuthMode.scala
@@ -1,0 +1,9 @@
+package com.danielasfregola.twitter4s.entities.enums
+
+object OAuthMode extends Enumeration {
+  type OAuthMode = Value
+
+  val UseOAuth1 = Value(1)
+  val UseOAuthBearerToken = Value(2)
+  val MixedAuth = Value(3)
+}

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/BearerTokenClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/BearerTokenClient.scala
@@ -1,0 +1,68 @@
+package com.danielasfregola.twitter4s.http.clients
+
+import akka.http.scaladsl.client.RequestBuilding
+import akka.http.scaladsl.model.HttpMethods.{DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT}
+import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
+import akka.http.scaladsl.model.{ContentType, HttpEntity, HttpMethod, HttpRequest, MediaTypes, Multipart, Uri}
+import akka.stream.Materializer
+import com.danielasfregola.twitter4s.http.marshalling.{BodyEncoder, Parameters}
+import com.danielasfregola.twitter4s.util.Configurations
+
+import scala.concurrent.{ExecutionContext, Future}
+
+private[twitter4s] trait BearerTokenClient extends CommonClient with RequestBuilding {
+
+  // Perhaps in the future a client can be introduced to derive bearer tokens using oauth 2.0
+  // https://developer.twitter.com/en/docs/authentication/oauth-2-0/bearer-tokens
+  // For now we can just pull the token directly out of configuration
+  private val bearerToken = Configurations.bearerToken
+
+  def withBearerTokenHeader(callback: Option[String])(
+      implicit materializer: Materializer): HttpRequest => Future[HttpRequest] = { request =>
+    implicit val ec = materializer.executionContext
+    // I'm sure there's a less nasty way to do this?
+    Future {
+      request.withHeaders(request.headers :+ Authorization(OAuth2BearerToken(bearerToken)))
+    }
+  }
+
+  override val Get = new BearerTokenRequestBuilder(GET)
+  override val Post = new BearerTokenRequestBuilder(POST)
+  override val Put = new BearerTokenRequestBuilder(PUT)
+  override val Patch = new BearerTokenRequestBuilder(PATCH)
+  override val Delete = new BearerTokenRequestBuilder(DELETE)
+  override val Options = new BearerTokenRequestBuilder(OPTIONS)
+  override val Head = new BearerTokenRequestBuilder(HEAD)
+
+  private[twitter4s] class BearerTokenRequestBuilder(method: HttpMethod)
+      extends RequestBuilder(method)
+      with BodyEncoder {
+    def apply(uri: String, parameters: Parameters): HttpRequest = {
+      if (parameters.toString.nonEmpty) apply(s"$uri?$parameters")
+      else apply(uri)
+    }
+
+    def apply(uri: String, content: Product): HttpRequest = {
+      val data = toBodyAsEncodedParams(content)
+      val contentType = ContentType(MediaTypes.`application/x-www-form-urlencoded`)
+      apply(uri, data, contentType)
+    }
+
+    def asJson[A <: AnyRef](uri: String, content: A): HttpRequest = {
+      val jsonData = org.json4s.native.Serialization.write(content)
+      val contentType = ContentType(MediaTypes.`application/json`)
+      apply(uri, jsonData, contentType)
+    }
+
+    def apply(uri: String, content: Product, contentType: ContentType): HttpRequest = {
+      val data = toBodyAsParams(content)
+      apply(uri, data, contentType)
+    }
+
+    def apply(uri: String, data: String, contentType: ContentType): HttpRequest =
+      apply(uri).withEntity(HttpEntity(data).withContentType(contentType))
+
+    def apply(uri: String, multipartFormData: Multipart.FormData)(implicit ec: ExecutionContext): HttpRequest =
+      apply(Uri(uri), Some(multipartFormData))
+  }
+}

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/BearerTokenClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/BearerTokenClient.scala
@@ -2,9 +2,8 @@ package com.danielasfregola.twitter4s.http.clients
 
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.HttpMethods._
-import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
 import akka.http.scaladsl.model._
-import akka.stream.Materializer
+import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
 import com.danielasfregola.twitter4s.http.marshalling.{BodyEncoder, Parameters}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -13,13 +12,8 @@ private[twitter4s] class BearerTokenClient(bearerToken: String) extends CommonCl
   override def withLogRequest: Boolean = false
   override def withLogRequestResponse: Boolean = false
 
-  def withBearerTokenHeader(callback: Option[String])(
-      implicit materializer: Materializer): HttpRequest => Future[HttpRequest] = { request =>
-    implicit val ec = materializer.executionContext
-    // I'm sure there's a less nasty way to do this?
-    Future {
-      request.withHeaders(request.headers :+ Authorization(OAuth2BearerToken(bearerToken)))
-    }
+  def withBearerTokenHeader(callback: Option[String]): HttpRequest => Future[HttpRequest] = { request =>
+    Future.successful(request.addHeader(Authorization(OAuth2BearerToken(bearerToken))))
   }
 
   override val Get = new BearerTokenRequestBuilder(GET)

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/BearerTokenClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/BearerTokenClient.scala
@@ -1,21 +1,17 @@
 package com.danielasfregola.twitter4s.http.clients
 
 import akka.http.scaladsl.client.RequestBuilding
-import akka.http.scaladsl.model.HttpMethods.{DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT}
+import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
-import akka.http.scaladsl.model.{ContentType, HttpEntity, HttpMethod, HttpRequest, MediaTypes, Multipart, Uri}
+import akka.http.scaladsl.model._
 import akka.stream.Materializer
 import com.danielasfregola.twitter4s.http.marshalling.{BodyEncoder, Parameters}
-import com.danielasfregola.twitter4s.util.Configurations
 
 import scala.concurrent.{ExecutionContext, Future}
 
-private[twitter4s] trait BearerTokenClient extends CommonClient with RequestBuilding {
-
-  // Perhaps in the future a client can be introduced to derive bearer tokens using oauth 2.0
-  // https://developer.twitter.com/en/docs/authentication/oauth-2-0/bearer-tokens
-  // For now we can just pull the token directly out of configuration
-  private val bearerToken = Configurations.bearerToken
+private[twitter4s] class BearerTokenClient(bearerToken: String) extends CommonClient with RequestBuilding {
+  override def withLogRequest: Boolean = false
+  override def withLogRequestResponse: Boolean = false
 
   def withBearerTokenHeader(callback: Option[String])(
       implicit materializer: Materializer): HttpRequest => Future[HttpRequest] = { request =>

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/Client.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/Client.scala
@@ -4,16 +4,12 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
-import com.danielasfregola.twitter4s.http.oauth.OAuth1Provider
 
 import scala.concurrent.Future
 
-trait Client extends OAuthClient {
-
+trait Client extends CommonClient {
   val withLogRequest = false
   val withLogRequestResponse = true
-
-  def oauthProvider: OAuth1Provider
 
   protected def sendAndReceive[T](request: HttpRequest, f: HttpResponse => Future[T])(
       implicit system: ActorSystem,
@@ -29,5 +25,4 @@ trait Client extends OAuthClient {
       .mapAsync(1)(implicit response => unmarshal(requestStartTime, f))
       .runWith(Sink.head)
   }
-
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/Client.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/Client.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 
 trait Client extends CommonClient {
   val withLogRequest = false
-  val withLogRequestResponse = true
+  val withLogRequestResponse = false
 
   protected def sendAndReceive[T](request: HttpRequest, f: HttpResponse => Future[T])(
       implicit system: ActorSystem,

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/OAuthClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/OAuthClient.scala
@@ -4,14 +4,18 @@ import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
 import akka.stream.Materializer
+import com.danielasfregola.twitter4s.entities.{AccessToken, ConsumerToken}
 import com.danielasfregola.twitter4s.http.marshalling.{BodyEncoder, Parameters}
 import com.danielasfregola.twitter4s.http.oauth.OAuth1Provider
 
 import scala.concurrent.{ExecutionContext, Future}
 
-private[twitter4s] trait OAuthClient extends CommonClient with RequestBuilding {
-
-  def oauthProvider: OAuth1Provider
+private[twitter4s] class OAuthClient(consumerToken: ConsumerToken, accessToken: AccessToken)
+    extends CommonClient
+    with RequestBuilding {
+  lazy val oauthProvider = new OAuth1Provider(consumerToken, Some(accessToken))
+  override def withLogRequest: Boolean = false
+  override def withLogRequestResponse: Boolean = false
 
   def withOAuthHeader(callback: Option[String])(
       implicit materializer: Materializer): HttpRequest => Future[HttpRequest] = { request =>
@@ -64,7 +68,5 @@ private[twitter4s] trait OAuthClient extends CommonClient with RequestBuilding {
 
     def apply(uri: String, multipartFormData: Multipart.FormData)(implicit ec: ExecutionContext): HttpRequest =
       apply(Uri(uri), Some(multipartFormData))
-
   }
-
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/authentication/oauth/TwitterOAuthClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/authentication/oauth/TwitterOAuthClient.scala
@@ -44,7 +44,7 @@ trait TwitterOAuthClient {
                    x_auth_access_type: Option[AccessType] = None): Future[OAuthRequestToken] = {
     import authenticationClient._
     val parameters = RequestTokenParameters(x_auth_access_type)
-    Post(s"$oauthUrl/request_token", parameters).respondAs[OAuthRequestToken](oauth_callback)
+    oauthClient.Post(s"$oauthUrl/request_token", parameters).respondAs[OAuthRequestToken](oauth_callback)
   }
 
   /** Allows a Consumer application to use an OAuth request_token to request user authorization.
@@ -116,7 +116,7 @@ trait TwitterOAuthClient {
                                            x_auth_password = Some(x_auth_password),
                                            x_auth_mode = Some("client_auth"))
     import authenticationClient._
-    Post(s"$oauthUrl/access_token", parameters).respondAs[OAuthAccessToken]
+    oauthClient.Post(s"$oauthUrl/access_token", parameters).respondAs[OAuthAccessToken]
   }
 
   /** Allows a Consumer application to exchange the OAuth Request Token for an OAuth Access Token using OAuth 1.0.
@@ -134,6 +134,6 @@ trait TwitterOAuthClient {
   def accessToken(token: RequestToken, oauth_verifier: String): Future[OAuthAccessToken] = {
     val parameters = AccessTokenParameters(oauth_token = Some(token.key), oauth_verifier = Some(oauth_verifier))
     import authenticationClient._
-    Post(s"$oauthUrl/access_token", parameters).respondAs[OAuthAccessToken]
+    oauthClient.Post(s"$oauthUrl/access_token", parameters).respondAs[OAuthAccessToken]
   }
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/RestClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/RestClient.scala
@@ -1,43 +1,67 @@
 package com.danielasfregola.twitter4s.http.clients.rest
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.client.RequestBuilding
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.{ActorMaterializer, Materializer}
+import com.danielasfregola.twitter4s.entities.enums.OAuthMode.{MixedAuth, OAuthMode, UseOAuth1, UseOAuthBearerToken}
 import com.danielasfregola.twitter4s.entities.{AccessToken, ConsumerToken, RateLimit, RatedData}
-import com.danielasfregola.twitter4s.http.clients.Client
-import com.danielasfregola.twitter4s.http.oauth.OAuth1Provider
+import com.danielasfregola.twitter4s.http.clients.{BearerTokenClient, Client, OAuthClient}
+import com.danielasfregola.twitter4s.http.marshalling.{BodyEncoder, Parameters}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-private[twitter4s] class RestClient(val consumerToken: ConsumerToken, val accessToken: AccessToken)(
-    implicit val system: ActorSystem)
-    extends Client {
+private[twitter4s] class RestClient(val authMode: OAuthMode)(implicit val system: ActorSystem)
+    extends Client
+    with RequestBuilding {
+  var v1Client: OAuthClient = _
+  var v2Client: BearerTokenClient = _
 
-  lazy val oauthProvider = new OAuth1Provider(consumerToken, Some(accessToken))
+  def this(consumerToken: ConsumerToken, accessToken: AccessToken)(implicit system: ActorSystem) {
+    this(UseOAuth1)
+    this.v1Client = new OAuthClient(consumerToken, accessToken)
+  }
+
+  def this(bearerToken: String)(implicit system: ActorSystem) {
+    this(UseOAuthBearerToken)
+    v2Client = new BearerTokenClient(bearerToken)
+  }
 
   private[twitter4s] implicit class RichRestHttpRequest(val request: HttpRequest) {
-
     implicit val materializer = ActorMaterializer()
     implicit val ec = materializer.executionContext
 
+    private def withHeader(callback: Option[String])(
+        implicit materializer: Materializer): HttpRequest => Future[HttpRequest] = {
+      // Depending on our authMode, we may want to use a different helper function
+      authMode match {
+        case UseOAuth1           => v1Client.withOAuthHeader(callback)
+        case UseOAuthBearerToken => v2Client.withBearerTokenHeader(callback)
+        case MixedAuth           => v1Client.withOAuthHeader(callback)
+        case _                   => v1Client.withOAuthHeader(callback)
+      }
+    }
+
     def respondAs[T: Manifest]: Future[T] =
       for {
-        requestWithAuth <- withOAuthHeader(None)(materializer)(request)
+        requestWithAuth <- withHeader(None)(materializer)(request)
         t <- sendReceiveAs[T](requestWithAuth)
       } yield t
 
     def respondAsRated[T: Manifest]: Future[RatedData[T]] =
       for {
-        requestWithAuth <- withOAuthHeader(None)(materializer)(request)
+        requestWithAuth <- withHeader(None)(materializer)(request)
         t <- sendReceiveAsRated[T](requestWithAuth)
       } yield t
 
     def sendAsFormData: Future[Unit] =
       for {
-        requestWithAuth <- withSimpleOAuthHeader(None)(materializer)(request)
+        requestWithAuth <- withHeader(None)(materializer)(request)
         _ <- sendIgnoreResponse(requestWithAuth)
       } yield ()
+
   }
 
   def sendIgnoreResponse(httpRequest: HttpRequest)(implicit system: ActorSystem,
@@ -62,5 +86,43 @@ private[twitter4s] class RestClient(val consumerToken: ConsumerToken, val access
       data.map(d => RatedData(rate, d))
     }
     sendAndReceive(httpRequest, unmarshallRated)
+  }
+
+  override val Get = new DynamicRequestBuilder(GET)
+  override val Post = new DynamicRequestBuilder(POST)
+  override val Put = new DynamicRequestBuilder(PUT)
+  override val Patch = new DynamicRequestBuilder(PATCH)
+  override val Delete = new DynamicRequestBuilder(DELETE)
+  override val Options = new DynamicRequestBuilder(OPTIONS)
+  override val Head = new DynamicRequestBuilder(HEAD)
+
+  private[twitter4s] class DynamicRequestBuilder(method: HttpMethod) extends RequestBuilder(method) with BodyEncoder {
+    def apply(uri: String, parameters: Parameters): HttpRequest = {
+      if (parameters.toString.nonEmpty) apply(s"$uri?$parameters")
+      else apply(uri)
+    }
+
+    def apply(uri: String, content: Product): HttpRequest = {
+      val data = toBodyAsEncodedParams(content)
+      val contentType = ContentType(MediaTypes.`application/x-www-form-urlencoded`)
+      apply(uri, data, contentType)
+    }
+
+    def asJson[A <: AnyRef](uri: String, content: A): HttpRequest = {
+      val jsonData = org.json4s.native.Serialization.write(content)
+      val contentType = ContentType(MediaTypes.`application/json`)
+      apply(uri, jsonData, contentType)
+    }
+
+    def apply(uri: String, content: Product, contentType: ContentType): HttpRequest = {
+      val data = toBodyAsParams(content)
+      apply(uri, data, contentType)
+    }
+
+    def apply(uri: String, data: String, contentType: ContentType): HttpRequest =
+      apply(uri).withEntity(HttpEntity(data).withContentType(contentType))
+
+    def apply(uri: String, multipartFormData: Multipart.FormData)(implicit ec: ExecutionContext): HttpRequest =
+      apply(Uri(uri), Some(multipartFormData))
   }
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClient.scala
@@ -2,14 +2,16 @@ package com.danielasfregola.twitter4s.http
 package clients.rest.search
 
 import java.time.LocalDate
-
 import com.danielasfregola.twitter4s.entities._
 import com.danielasfregola.twitter4s.entities.enums.Language._
 import com.danielasfregola.twitter4s.entities.enums.ResultType._
 import com.danielasfregola.twitter4s.entities.enums.TweetMode.TweetMode
 import com.danielasfregola.twitter4s.entities.enums.{ResultType, TweetMode}
 import com.danielasfregola.twitter4s.http.clients.rest.RestClient
-import com.danielasfregola.twitter4s.http.clients.rest.search.parameters.TweetSearchParameters
+import com.danielasfregola.twitter4s.http.clients.rest.search.parameters.{
+  TweetSearchAllParamaters,
+  TweetSearchParameters
+}
 import com.danielasfregola.twitter4s.util.Configurations._
 
 import scala.concurrent.Future
@@ -21,6 +23,7 @@ trait TwitterSearchClient {
   protected val restClient: RestClient
 
   private val searchUrl = s"$apiTwitterUrl/$twitterVersion/search"
+  private val searchAllUrl = s"$apiTwitterUrl/$twitterVersionNext/search/all"
 
   /** Returns a collection of relevant Tweets matching a specified query.
     * For more information see
@@ -95,5 +98,35 @@ trait TwitterSearchClient {
       tweet_mode
     )
     Get(s"$searchUrl/tweets.json", parameters).respondAsRated[StatusSearch]
+  }
+
+  /** Returns a collection of relevant tweets matching a query. This endpoint is only available to those using the Academic research product track.
+    * For more information, see:
+    * <a href="https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-all" target="_blank">
+    *   https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-all</a>
+    *
+    * @param query          : One query for matching Tweets. Up to 1024 characters.
+    * @param max_results    : Optional. The maximum number of search results to be returned by a request.
+    *                       A number between 10 and the system limit (currently 500).
+    *                       By default, a request response will return 10 results.
+    * @param next_token     : Optional. This parameter is used to get the next 'page' of results.
+    *                       The value used with the parameter is pulled directly from the response provided by the API, and should not be modified.
+    * @param start_time     : Optional. The oldest UTC timestamp from which the Tweets will be provided.
+    *                       Timestamp is in second granularity and is inclusive (for example, 12:00:01 includes the first second of the minute).
+    *                       By default, a request will return Tweets from up to 30 days ago if you do not include this parameter.
+    * @param end_time       : Optional. The newest, most recent UTC timestamp to which the Tweets will be provided.
+    *                       Timestamp is in second granularity and is exclusive (for example, 12:00:01 excludes the first second of the minute).
+    *                       If used without start_time, Tweets from 30 days before end_time will be returned by default.
+    *                       If not specified, end_time will default to [now - 30 seconds].
+    * @return The representation of the search results.
+    */
+  def searchAllTweet(query: String,
+                     max_results: Int = 10,
+                     next_token: Option[String],
+                     start_time: Option[LocalDate],
+                     end_time: Option[LocalDate]): Future[RatedData[StatusSearch]] = {
+    import restClient._
+    val parameters = TweetSearchAllParamaters(query, max_results, next_token, start_time, end_time)
+    Get(s"$searchAllUrl", parameters).respondAsRated[StatusSearch]
   }
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClient.scala
@@ -124,9 +124,10 @@ trait TwitterSearchClient {
                      max_results: Int = 10,
                      next_token: Option[String] = None,
                      start_time: Option[LocalDate] = None,
-                     end_time: Option[LocalDate] = None): Future[RatedData[StatusFullSearch]] = {
+                     end_time: Option[LocalDate] = None,
+                     expansions: Option[String] = None): Future[RatedData[StatusFullSearch]] = {
     import restClient._
-    val parameters = TweetSearchAllParamaters(query, max_results, next_token, start_time, end_time)
+    val parameters = TweetSearchAllParamaters(query, max_results, next_token, start_time, end_time, expansions)
     Get(s"$searchAllUrl", parameters).respondAsRated[StatusFullSearch]
   }
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClient.scala
@@ -23,7 +23,7 @@ trait TwitterSearchClient {
   protected val restClient: RestClient
 
   private val searchUrl = s"$apiTwitterUrl/$twitterVersion/search"
-  private val searchAllUrl = s"$apiTwitterUrl/$twitterVersionNext/search/all"
+  private val searchAllUrl = s"$apiTwitterUrl/$twitterVersionNext/tweets/search/all"
 
   /** Returns a collection of relevant Tweets matching a specified query.
     * For more information see
@@ -122,11 +122,11 @@ trait TwitterSearchClient {
     */
   def searchAllTweet(query: String,
                      max_results: Int = 10,
-                     next_token: Option[String],
-                     start_time: Option[LocalDate],
-                     end_time: Option[LocalDate]): Future[RatedData[StatusSearch]] = {
+                     next_token: Option[String] = None,
+                     start_time: Option[LocalDate] = None,
+                     end_time: Option[LocalDate] = None): Future[RatedData[StatusFullSearch]] = {
     import restClient._
     val parameters = TweetSearchAllParamaters(query, max_results, next_token, start_time, end_time)
-    Get(s"$searchAllUrl", parameters).respondAsRated[StatusSearch]
+    Get(s"$searchAllUrl", parameters).respondAsRated[StatusFullSearch]
   }
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/parameters/TweetSearchAllParamaters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/parameters/TweetSearchAllParamaters.scala
@@ -1,0 +1,11 @@
+package com.danielasfregola.twitter4s.http.clients.rest.search.parameters
+
+import java.time.LocalDate
+import com.danielasfregola.twitter4s.http.marshalling.Parameters
+
+case class TweetSearchAllParamaters(q: String,
+                                    max_results: Int = 10,
+                                    next_token: Option[String],
+                                    start_time: Option[LocalDate],
+                                    end_time: Option[LocalDate])
+    extends Parameters

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/parameters/TweetSearchAllParamaters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/parameters/TweetSearchAllParamaters.scala
@@ -3,7 +3,7 @@ package com.danielasfregola.twitter4s.http.clients.rest.search.parameters
 import java.time.LocalDate
 import com.danielasfregola.twitter4s.http.marshalling.Parameters
 
-case class TweetSearchAllParamaters(q: String,
+case class TweetSearchAllParamaters(query: String,
                                     max_results: Int = 10,
                                     next_token: Option[String],
                                     start_time: Option[LocalDate],

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/parameters/TweetSearchAllParamaters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/search/parameters/TweetSearchAllParamaters.scala
@@ -7,5 +7,6 @@ case class TweetSearchAllParamaters(query: String,
                                     max_results: Int = 10,
                                     next_token: Option[String],
                                     start_time: Option[LocalDate],
-                                    end_time: Option[LocalDate])
+                                    end_time: Option[LocalDate],
+                                    expansions: Option[String])
     extends Parameters

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/StreamingClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/streaming/StreamingClient.scala
@@ -19,14 +19,14 @@ import scala.util.{Failure, Success, Try}
 
 private[twitter4s] class StreamingClient(val consumerToken: ConsumerToken, val accessToken: AccessToken)(
     implicit val system: ActorSystem)
-    extends OAuthClient {
+    extends OAuthClient(consumerToken = consumerToken, accessToken = accessToken) {
 
-  val withLogRequest = true
-  val withLogRequestResponse = false
+  override val withLogRequest = true
+  override val withLogRequestResponse = false
 
   def preProcessing(): Unit = ()
 
-  lazy val oauthProvider = new OAuth1Provider(consumerToken, Some(accessToken))
+  override lazy val oauthProvider = new OAuth1Provider(consumerToken, Some(accessToken))
 
   private[twitter4s] implicit class RichStreamingHttpRequest(val request: HttpRequest) {
 

--- a/src/main/scala/com/danielasfregola/twitter4s/util/Configurations.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/util/Configurations.scala
@@ -43,5 +43,4 @@ trait ConfigurationDetector {
   protected def environmentVariable(name: String): Option[String] = Properties.envOrNone(name)
 
   protected def configuration(path: String): String = config.getString(path)
-
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/util/Configurations.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/util/Configurations.scala
@@ -14,6 +14,8 @@ object Configurations extends ConfigurationDetector {
   lazy val accessTokenKey = envVarOrConfig("TWITTER_ACCESS_TOKEN_KEY", "twitter.access.key")
   lazy val accessTokenSecret = envVarOrConfig("TWITTER_ACCESS_TOKEN_SECRET", "twitter.access.secret")
 
+  lazy val bearerToken = envVarOrConfig("TWITTER_BEARER_TOKEN", "twitter.bearer.token")
+
   lazy val twitterVersion = "1.1"
 
   lazy val apiTwitterUrl = config.getString("twitter.rest.api")

--- a/src/test/resources/fixtures/rest/search/fullArchiveSearch.json
+++ b/src/test/resources/fixtures/rest/search/fullArchiveSearch.json
@@ -1,0 +1,50 @@
+{
+  "data": [
+    {
+      "id": "1362095219810910215",
+      "text": "Navigate in large Scala projects easily with Silver Searcher and Ctags. #scala https://t.co/UShiZbMFEj"
+    },
+    {
+      "id": "1362094483773534208",
+      "text": "Buscamos #Scala #Developer para importante start-up de desarrollo de software y tecnologías en Blockchain, realidad aumentada, Data Analytics y firma digital.\n🤲 La empresa brinda:\nRelación de dependencia directa.\nPrepaga.\nFlexibilidad horaria.\nInfo &gt; https://t.co/qMWHRD13lS https://t.co/DUPgwSUFOS"
+    },
+    {
+      "id": "1362094217116311552",
+      "text": "RT @Hal______9000: #artificialintelligence #ML #bot #sussex #cambridge #caltech #lisp #virtualreality #scheme #clojure #drawing #comic #has…"
+    },
+    {
+      "id": "1362094102708379649",
+      "text": "RT @Hal______9000: #artificialintelligence #ML #bot #sussex #cambridge #caltech #lisp #virtualreality #scheme #clojure #drawing #comic #has…"
+    },
+    {
+      "id": "1362094080260509707",
+      "text": "#artificialintelligence #ML #bot #sussex #cambridge #caltech #lisp #virtualreality #scheme #clojure #drawing #comic #haskell #zine #art #django #videoart #psychedelic #trip #ai #python #nodejs #Stuhlbarg #Winstead #scala  #simulation #erlang #software #javascript #computer #linux https://t.co/7gKtXJCjTl"
+    },
+    {
+      "id": "1362092755837739011",
+      "text": "Scala is a multi-paradigm programming language that combines the fundamental \nideas and abstractions of modern typed functional-programming languages,Â ... #Scala #ProgrammingParadigm https://t.co/YlYF83Iaee https://t.co/xYdhW8T5YN"
+    },
+    {
+      "id": "1362092474135683075",
+      "text": "RT @riccardo_cardin: Mailboxes are one of the fundamental parts of the Actor Model. In @baeldung, we know it, and we wrote an article on ho…"
+    },
+    {
+      "id": "1362092376966258689",
+      "text": "Aleron has a new Data Engineer open position\n\n#hiring #Python #Hadoop #Scala\n\n⬇️⬇️ Apply here ⬇️⬇️\n\nhttps://t.co/ad1XRbGPi0"
+    },
+    {
+      "id": "1362092013219414020",
+      "text": "I'm currently studying functional programming from FP in Scala, the red book.\nIf anyone is interested in pairing up then please DM me. I'm currently on 7th chapter.\n#Scala #functionalprogramming"
+    },
+    {
+      "id": "1362088936521220103",
+      "text": "@binance #XLA #Scala 😍"
+    }
+  ],
+  "meta": {
+    "newest_id": "1362095219810910215",
+    "oldest_id": "1362088936521220103",
+    "result_count": 10,
+    "next_token": "b26v89c19zqg8o3fosns2opmei7w991zxnp3ogli9803h"
+  }
+}

--- a/src/test/resources/twitter/rest/search/fullArchiveSearch.json
+++ b/src/test/resources/twitter/rest/search/fullArchiveSearch.json
@@ -1,0 +1,50 @@
+{
+  "data": [
+    {
+      "id": "1362095219810910215",
+      "text": "Navigate in large Scala projects easily with Silver Searcher and Ctags. #scala https://t.co/UShiZbMFEj"
+    },
+    {
+      "id": "1362094483773534208",
+      "text": "Buscamos #Scala #Developer para importante start-up de desarrollo de software y tecnologías en Blockchain, realidad aumentada, Data Analytics y firma digital.\n🤲 La empresa brinda:\nRelación de dependencia directa.\nPrepaga.\nFlexibilidad horaria.\nInfo &gt; https://t.co/qMWHRD13lS https://t.co/DUPgwSUFOS"
+    },
+    {
+      "id": "1362094217116311552",
+      "text": "RT @Hal______9000: #artificialintelligence #ML #bot #sussex #cambridge #caltech #lisp #virtualreality #scheme #clojure #drawing #comic #has…"
+    },
+    {
+      "id": "1362094102708379649",
+      "text": "RT @Hal______9000: #artificialintelligence #ML #bot #sussex #cambridge #caltech #lisp #virtualreality #scheme #clojure #drawing #comic #has…"
+    },
+    {
+      "id": "1362094080260509707",
+      "text": "#artificialintelligence #ML #bot #sussex #cambridge #caltech #lisp #virtualreality #scheme #clojure #drawing #comic #haskell #zine #art #django #videoart #psychedelic #trip #ai #python #nodejs #Stuhlbarg #Winstead #scala  #simulation #erlang #software #javascript #computer #linux https://t.co/7gKtXJCjTl"
+    },
+    {
+      "id": "1362092755837739011",
+      "text": "Scala is a multi-paradigm programming language that combines the fundamental \nideas and abstractions of modern typed functional-programming languages,Â ... #Scala #ProgrammingParadigm https://t.co/YlYF83Iaee https://t.co/xYdhW8T5YN"
+    },
+    {
+      "id": "1362092474135683075",
+      "text": "RT @riccardo_cardin: Mailboxes are one of the fundamental parts of the Actor Model. In @baeldung, we know it, and we wrote an article on ho…"
+    },
+    {
+      "id": "1362092376966258689",
+      "text": "Aleron has a new Data Engineer open position\n\n#hiring #Python #Hadoop #Scala\n\n⬇️⬇️ Apply here ⬇️⬇️\n\nhttps://t.co/ad1XRbGPi0"
+    },
+    {
+      "id": "1362092013219414020",
+      "text": "I'm currently studying functional programming from FP in Scala, the red book.\nIf anyone is interested in pairing up then please DM me. I'm currently on 7th chapter.\n#Scala #functionalprogramming"
+    },
+    {
+      "id": "1362088936521220103",
+      "text": "@binance #XLA #Scala 😍"
+    }
+  ],
+  "meta": {
+    "newest_id": "1362095219810910215",
+    "oldest_id": "1362088936521220103",
+    "result_count": 10,
+    "next_token": "b26v89c19zqg8o3fosns2opmei7w991zxnp3ogli9803h"
+  }
+}

--- a/src/test/scala/com/danielasfregola/twitter4s/helpers/ClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/helpers/ClientSpec.scala
@@ -1,7 +1,6 @@
 package com.danielasfregola.twitter4s.helpers
 
 import java.util.UUID
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
 import akka.pattern.ask
@@ -9,6 +8,7 @@ import akka.stream.{KillSwitches, Materializer, SharedKillSwitch}
 import akka.util.Timeout
 import akka.util.Timeout.durationToTimeout
 import com.danielasfregola.twitter4s.entities.streaming.StreamingMessage
+import com.danielasfregola.twitter4s.http.clients.OAuthClient
 import com.danielasfregola.twitter4s.http.clients.authentication.AuthenticationClient
 import com.danielasfregola.twitter4s.http.clients.rest.RestClient
 import com.danielasfregola.twitter4s.http.clients.streaming.StreamingClient
@@ -39,7 +39,7 @@ trait ClientSpec extends Spec {
 
   abstract class RestClientSpecContext extends RequestDSL with SpecContext {
 
-    protected val restClient = new RestClient(consumerToken, accessToken) {
+    protected val restClient = new RestClient(Some(new OAuthClient(consumerToken, accessToken))) {
 
       override def sendAndReceive[T](request: HttpRequest, f: HttpResponse => Future[T])(
           implicit system: ActorSystem,

--- a/src/test/scala/com/danielasfregola/twitter4s/helpers/Spec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/helpers/Spec.scala
@@ -15,6 +15,6 @@ trait Spec extends SpecificationLike with UriHelpers {
 
     val consumerToken = ConsumerToken("consumer-key", "consumer-secret")
     val accessToken = AccessToken("access-key", "access-secret")
-
+    val bearerToken = "bearerTokenBlahBlahBlah"
   }
 }

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClientSpec.scala
@@ -56,7 +56,7 @@ class TwitterSearchClientSpec extends ClientSpec {
         .expectRequest { request =>
           request.method === HttpMethods.GET
           request.uri.endpoint === "https://api.twitter.com/2/tweets/search/all"
-          request.uri.rawQueryString === Some("max_results=10&q=%23scala")
+          request.uri.rawQueryString === Some("max_results=10&query=%23scala")
         }
         .respondWithRated("/twitter/rest/search/fullArchiveSearch.json")
         .await

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/search/TwitterSearchClientSpec.scala
@@ -1,7 +1,7 @@
 package com.danielasfregola.twitter4s.http.clients.rest.search
 
 import akka.http.scaladsl.model.HttpMethods
-import com.danielasfregola.twitter4s.entities.{RatedData, StatusSearch}
+import com.danielasfregola.twitter4s.entities.{RatedData, StatusFullSearch, StatusSearch}
 import com.danielasfregola.twitter4s.helpers.ClientSpec
 
 class TwitterSearchClientSpec extends ClientSpec {
@@ -51,6 +51,17 @@ class TwitterSearchClientSpec extends ClientSpec {
       result.data === loadJsonAs[StatusSearch]("/fixtures/rest/search/tweets.json")
     }
 
+    "search for tweets (full archive)" in new TwitterSearchClientSpecContext {
+      val result: RatedData[StatusFullSearch] = when(searchAllTweet("#scala"))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === "https://api.twitter.com/2/tweets/search/all"
+          request.uri.rawQueryString === Some("max_results=10&q=%23scala")
+        }
+        .respondWithRated("/twitter/rest/search/fullArchiveSearch.json")
+        .await
+      result.rate_limit === rateLimit
+      result.data === loadJsonAs[StatusFullSearch]("/fixtures/rest/search/fullArchiveSearch.json")
+    }
   }
-
 }

--- a/src/test/scala/com/danielasfregola/twitter4s/util/ConfigurationDetectorSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/util/ConfigurationDetectorSpec.scala
@@ -64,7 +64,7 @@ class ConfigurationDetectorSpec extends Specification with Mockito {
       "if configuration from file does not exist" in {
         "throw an exception" in
           new ConfigurationDetectorSpecContext with NoEnvVariable with NoConfigFromFile {
-            envVarOrConfig(variableName, configName) === None
+            envVarOrConfig(variableName, configName) must throwA[RuntimeException]
           }
       }
     }

--- a/src/test/scala/com/danielasfregola/twitter4s/util/ConfigurationDetectorSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/util/ConfigurationDetectorSpec.scala
@@ -40,14 +40,14 @@ class ConfigurationDetectorSpec extends Specification with Mockito {
       "if configuration from file does not exists" in {
         "detect the configuration from the environment variable" in
           new ConfigurationDetectorSpecContext with WithEnvVariable with NoConfigFromFile {
-            envVarOrConfig(variableName, configName) === myConfigFromEnvVar
+            envVarOrConfig(variableName, configName) === Some(myConfigFromEnvVar)
           }
       }
 
       "if configuration from file exists" in {
         "detect the configuration from the environment variable" in
           new ConfigurationDetectorSpecContext with WithEnvVariable with WithConfigFromFile {
-            envVarOrConfig(variableName, configName) === myConfigFromEnvVar
+            envVarOrConfig(variableName, configName) === Some(myConfigFromEnvVar)
           }
       }
     }
@@ -57,14 +57,14 @@ class ConfigurationDetectorSpec extends Specification with Mockito {
       "if configuration from file exists" in {
         "detect the configuration from the configuration file" in
           new ConfigurationDetectorSpecContext with NoEnvVariable with WithConfigFromFile {
-            envVarOrConfig(variableName, configName) === myConfigFromFile
+            envVarOrConfig(variableName, configName) === Some(myConfigFromFile)
           }
       }
 
       "if configuration from file does not exist" in {
         "throw an exception" in
           new ConfigurationDetectorSpecContext with NoEnvVariable with NoConfigFromFile {
-            envVarOrConfig(variableName, configName) must throwA[RuntimeException]
+            envVarOrConfig(variableName, configName) === None
           }
       }
     }


### PR DESCRIPTION
Decouples Client from OAuthClient in order to support bearer-token authentication. Thus, we can use Bearer-token authentication for endpoints like [this one](https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-all)

- This adds REST support for the aforementioned full archive support endpoint
- This also adds support for [oauth 2.0 bearer token authentication](https://developer.twitter.com/en/docs/authentication/oauth-2-0). Note that bearer token derivation is not added, just using a bearer token that is passed

Related to #366 