### PR TITLE
Create V2UserLookupClient with User fields

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/TwitterRestV2Client.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/TwitterRestV2Client.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import com.danielasfregola.twitter4s.entities.{AccessToken, ConsumerToken}
 import com.danielasfregola.twitter4s.http.clients.rest.RestClient
 import com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.TwitterTweetLookupClient
+import com.danielasfregola.twitter4s.http.clients.rest.v2.users.TwitterUserLookupClient
 import com.danielasfregola.twitter4s.util.Configurations._
 import com.danielasfregola.twitter4s.util.SystemShutdown
 
@@ -22,6 +23,7 @@ class TwitterRestV2Client(val consumerToken: ConsumerToken, val accessToken: Acc
 
 trait V2RestClients
   extends TwitterTweetLookupClient
+  with TwitterUserLookupClient
 
 object TwitterRestV2Client {
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/Includes.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/Includes.scala
@@ -1,8 +1,0 @@
-package com.danielasfregola.twitter4s.entities.v2
-
-final case class Includes(tweets: Seq[Tweet]
-                          // users: Seq[User], // TODO: Pending addition of users model
-                          // places: Seq[Place], // TODO: Pending addition of places model
-                          // media: Seq[Media], // TODO: Pending addition of media model
-                          // polls: Seq[Polls] // TODO pending addition of polls model
-                          )

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/TweetIncludes.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/TweetIncludes.scala
@@ -1,0 +1,8 @@
+package com.danielasfregola.twitter4s.entities.v2
+
+final case class TweetIncludes(tweets: Seq[Tweet]
+                               // users: Seq[User], // TODO: Pending addition of users model
+                               // places: Seq[Place], // TODO: Pending addition of places model
+                               // media: Seq[Media], // TODO: Pending addition of media model
+                               // polls: Seq[Polls] // TODO pending addition of polls model
+                              )

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/User.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/User.scala
@@ -1,0 +1,23 @@
+package com.danielasfregola.twitter4s.entities.v2
+
+import java.time.Instant
+
+final case class User(id: String,
+                      name: String,
+                      username: String,
+                      created_at: Option[Instant],
+                      `protected`: Option[Boolean],
+                      withheld: Option[Withheld],
+                      location: Option[String],
+                      url: Option[String],
+                      description: Option[String],
+                      verified: Option[Boolean],
+                      entities: Option[UserEntities],
+                      profile_image_url: Option[String],
+                      public_metrics: Option[UserPublicMetrics],
+                      pinned_tweet_id: Option[String])
+
+final case class UserPublicMetrics(followers_count: Int,
+                                   following_count: Int,
+                                   tweet_count: Int,
+                                   listed_count: Int)

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/UserEntities.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/UserEntities.scala
@@ -1,0 +1,29 @@
+package com.danielasfregola.twitter4s.entities.v2
+
+final case class UserEntities(url: Option[UserURLContainer],
+                              description: Option[UserEntitiesDescription])
+
+final case class UserURLContainer(urls: Seq[UserEntitiesURL])
+
+final case class UserEntitiesURL(start: Int,
+                                 end: Int,
+                                 url: String,
+                                 expanded_url: String,
+                                 display_url: String)
+
+final case class UserEntitiesDescription(urls: Seq[UserEntitiesURL],
+                                         hashtags: Seq[UserEntitiesHashtag],
+                                         mentions: Seq[UserEntitiesMention],
+                                         cashtags: Seq[UserEntitiesCashtag])
+
+final case class UserEntitiesHashtag(start: Int,
+                                     end: Int,
+                                     tag: String)
+
+final case class UserEntitiesMention(start: Int,
+                                     end: Int,
+                                     username: String)
+
+final case class UserEntitiesCashtag(start: Int,
+                                     end: Int,
+                                     tag: String)

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/UserIncludes.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/UserIncludes.scala
@@ -1,0 +1,4 @@
+package com.danielasfregola.twitter4s.entities.v2
+
+case class UserIncludes(tweets: Seq[Tweet],
+                        users: Seq[User])

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/expansions/UserExpansions.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/expansions/UserExpansions.scala
@@ -1,0 +1,7 @@
+package com.danielasfregola.twitter4s.entities.v2.enums.expansions
+
+object UserExpansions extends Enumeration {
+  type Expansions = Value
+
+  val PinnedTweetId = Value("pinned_tweet_id")
+}

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/responses/TweetResponse.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/responses/TweetResponse.scala
@@ -1,7 +1,7 @@
 package com.danielasfregola.twitter4s.entities.v2.responses
 
-import com.danielasfregola.twitter4s.entities.v2.{Error, Includes, Tweet}
+import com.danielasfregola.twitter4s.entities.v2.{Error, TweetIncludes, Tweet}
 
 final case class TweetResponse(data: Option[Tweet],
-                               includes: Option[Includes],
+                               includes: Option[TweetIncludes],
                                errors: Seq[Error])

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/responses/TweetsResponse.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/responses/TweetsResponse.scala
@@ -1,7 +1,7 @@
 package com.danielasfregola.twitter4s.entities.v2.responses
 
-import com.danielasfregola.twitter4s.entities.v2.{Error, Includes, Tweet}
+import com.danielasfregola.twitter4s.entities.v2.{Error, TweetIncludes, Tweet}
 
 final case class TweetsResponse(data: Seq[Tweet],
-                                includes: Option[Includes],
+                                includes: Option[TweetIncludes],
                                 errors: Seq[Error])

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/responses/UserResponse.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/responses/UserResponse.scala
@@ -1,0 +1,7 @@
+package com.danielasfregola.twitter4s.entities.v2.responses
+
+import com.danielasfregola.twitter4s.entities.v2.{Error, UserIncludes, User}
+
+case class UserResponse(data: Option[User],
+                        includes: Option[UserIncludes],
+                        errors: Seq[Error])

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/responses/UsersResponse.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/responses/UsersResponse.scala
@@ -1,0 +1,7 @@
+package com.danielasfregola.twitter4s.entities.v2.responses
+
+import com.danielasfregola.twitter4s.entities.v2.{User, UserIncludes, Error}
+
+case class UsersResponse(data: Seq[User],
+                         includes: Option[UserIncludes],
+                         errors: Seq[Error])

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/TwitterUserLookupClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/TwitterUserLookupClient.scala
@@ -1,0 +1,214 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.users
+
+import com.danielasfregola.twitter4s.entities.RatedData
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.entities.v2.responses.{UserResponse, UsersResponse}
+import com.danielasfregola.twitter4s.http.clients.rest.RestClient
+import com.danielasfregola.twitter4s.http.clients.rest.v2.users.parameters._
+import com.danielasfregola.twitter4s.util.Configurations._
+
+import scala.concurrent.Future
+
+/** Implements the available requests for the v2 `user lookup` resource. */
+trait TwitterUserLookupClient {
+
+  protected val restClient: RestClient
+
+  private val userLookupUrl = s"$apiTwitterUrl/$twitterVersionV2/users"
+
+  /** Returns a variety of information about one or more users specified by the requested IDs.
+    * For more information see
+    * <a href="https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users" target="_blank">
+    * https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users</a>
+    *
+    * @param ids         : A comma separated list of user IDs. Up to 100 are allowed in a single request.
+    * @param expansions  : Optional, by default is `Seq.empty`
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/expansions>Expansions</a>
+    *                    enable you to request additional data objects that relate to the originally
+    *                    returned users. The ID that represents the expanded data object will be included directly
+    *                    in the user data object, but the expanded object metadata will be returned within the `includes`
+    *                    response object, and will also include the ID so that you can match this data object to the
+    *                    original user object.
+    * @param tweetFields : Optional, by default is `Seq.empty`
+    *                    This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                    enables you to select which specific
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet">Tweet fields</a>
+    *                    will deliver in each returned pinned Tweet. The Tweet fields will only return if the user has
+    *                    a pinned Tweet and if you've also included the `expansions=pinned_tweet_id` expansion in your
+    *                    request. While the referenced Tweet ID will be located in the original Tweet object, you will
+    *                    find this ID and all additional Tweet fields in the includes data object.
+    * @param userFields  : Optional, by default is `Seq.empty`
+    *                    This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                    enables you to select which specific
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user">user fields</a>
+    *                    will deliver in each returned User object. These specified user fields will display directly in
+    *                    the user data objects.
+    *
+    * @return : The representation of the search results.
+    */
+  def lookupUsers(ids: Seq[String],
+                  expansions: Seq[Expansions] = Seq.empty[Expansions],
+                  tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
+                  userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[UsersResponse]] = {
+    import restClient._
+
+    val parameters = UsersParameters(
+      ids,
+      expansions,
+      tweetFields,
+      userFields
+    )
+
+    Get(
+      s"$userLookupUrl",
+      parameters
+    ).respondAsRated[UsersResponse]
+  }
+
+  /** Returns a variety of information about a single user specified by the requested ID.
+    * For more information see
+    * <a href="https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-id" target="_blank">
+    * https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-id</a>
+    *
+    * @param id          : The ID of the user to lookup.
+    * @param expansions  : Optional, by default is `Seq.empty`
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/expansions>Expansions</a>
+    *                    enable you to request additional data objects that relate to the originally
+    *                    returned users. The ID that represents the expanded data object will be included directly
+    *                    in the user data object, but the expanded object metadata will be returned within the `includes`
+    *                    response object, and will also include the ID so that you can match this data object to the
+    *                    original user object.
+    * @param tweetFields : Optional, by default is `Seq.empty`
+    *                    This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                    enables you to select which specific
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet">Tweet fields</a>
+    *                    will deliver in each returned pinned Tweet. The Tweet fields will only return if the user has
+    *                    a pinned Tweet and if you've also included the `expansions=pinned_tweet_id` expansion in your
+    *                    request. While the referenced Tweet ID will be located in the original Tweet object, you will
+    *                    find this ID and all additional Tweet fields in the includes data object.
+    * @param userFields  : Optional, by default is `Seq.empty`
+    *                    This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                    enables you to select which specific
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user">user fields</a>
+    *                    will deliver in each returned User object. These specified user fields will display directly in
+    *                    the user data objects.
+    *
+    * @return : The representation of the search results.
+    */
+  def lookupUser(id: String,
+                 expansions: Seq[Expansions] = Seq.empty[Expansions],
+                 tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
+                 userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[UserResponse]] = {
+    import restClient._
+
+    val parameters = UserParameters(
+      expansions,
+      tweetFields,
+      userFields
+    )
+
+    Get(
+      s"$userLookupUrl/$id",
+      parameters
+    ).respondAsRated[UserResponse]
+  }
+
+  /** Returns a variety of information about one or more users specified by their usernames.
+    * For more information see
+    * <a href="https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-by" target="_blank">
+    * https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-by</a>
+    *
+    * @param usernames   : A comma separated list of Twitter usernames (handles). Up to 100 are allowed in a single request.
+    * @param expansions  : Optional, by default is `Seq.empty`
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/expansions>Expansions</a>
+    *                    enable you to request additional data objects that relate to the originally
+    *                    returned users. The ID that represents the expanded data object will be included directly
+    *                    in the user data object, but the expanded object metadata will be returned within the `includes`
+    *                    response object, and will also include the ID so that you can match this data object to the
+    *                    original user object.
+    * @param tweetFields : Optional, by default is `Seq.empty`
+    *                    This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                    enables you to select which specific
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet">Tweet fields</a>
+    *                    will deliver in each returned pinned Tweet. The Tweet fields will only return if the user has
+    *                    a pinned Tweet and if you've also included the `expansions=pinned_tweet_id` expansion in your
+    *                    request. While the referenced Tweet ID will be located in the original Tweet object, you will
+    *                    find this ID and all additional Tweet fields in the includes data object.
+    * @param userFields  : Optional, by default is `Seq.empty`
+    *                    This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                    enables you to select which specific
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user">user fields</a>
+    *                    will deliver in each returned User object. These specified user fields will display directly in
+    *                    the user data objects.
+    *
+    * @return : The representation of the search results.
+    */
+  def lookupUsersByUsernames(usernames: Seq[String],
+                             expansions: Seq[Expansions] = Seq.empty[Expansions],
+                             tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
+                             userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[UsersResponse]] = {
+    import restClient._
+
+    val parameters = UsersByUsernamesParameters(
+      usernames,
+      expansions,
+      tweetFields,
+      userFields
+    )
+
+    Get(
+      s"$userLookupUrl/by",
+      parameters
+    ).respondAsRated[UsersResponse]
+  }
+
+  /** Returns a variety of information about a single user specified by the requested username.
+    * For more information see
+    * <a href="https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-by-username-username" target="_blank">
+    * https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-by-username-username</a>
+    *
+    * @param username    : The Twitter username (handle) of the user.
+    * @param expansions  : Optional, by default is `Seq.empty`
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/expansions>Expansions</a>
+    *                    enable you to request additional data objects that relate to the originally
+    *                    returned users. The ID that represents the expanded data object will be included directly
+    *                    in the user data object, but the expanded object metadata will be returned within the `includes`
+    *                    response object, and will also include the ID so that you can match this data object to the
+    *                    original user object.
+    * @param tweetFields : Optional, by default is `Seq.empty`
+    *                    This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                    enables you to select which specific
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet">Tweet fields</a>
+    *                    will deliver in each returned pinned Tweet. The Tweet fields will only return if the user has
+    *                    a pinned Tweet and if you've also included the `expansions=pinned_tweet_id` expansion in your
+    *                    request. While the referenced Tweet ID will be located in the original Tweet object, you will
+    *                    find this ID and all additional Tweet fields in the includes data object.
+    * @param userFields  : Optional, by default is `Seq.empty`
+    *                    This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                    enables you to select which specific
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user">user fields</a>
+    *                    will deliver in each returned User object. These specified user fields will display directly in
+    *                    the user data objects.
+    *
+    * @return : The representation of the search results.
+    */
+  def lookupUserByUsername(username: String,
+                           expansions: Seq[Expansions] = Seq.empty[Expansions],
+                           tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
+                           userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[UserResponse]] = {
+    import restClient._
+
+    val parameters = UserByUsernameParameters(
+      expansions,
+      tweetFields,
+      userFields
+    )
+
+    Get(
+      s"$userLookupUrl/by/username/$username",
+      parameters
+    ).respondAsRated[UserResponse]
+  }
+}

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UserByUsernameParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UserByUsernameParameters.scala
@@ -1,0 +1,10 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.users.parameters
+
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.http.marshalling.Parameters
+
+private[twitter4s] final case class UserByUsernameParameters(expansions: Seq[Expansions],
+                                                             `tweet.fields`: Seq[TweetFields] = Seq.empty[TweetFields],
+                                                             `user.fields`: Seq[UserFields] = Seq.empty[UserFields]) extends Parameters

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UserParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UserParameters.scala
@@ -1,0 +1,10 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.users.parameters
+
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.http.marshalling.Parameters
+
+private[twitter4s] final case class UserParameters(expansions: Seq[Expansions],
+                                                   `tweet.fields`: Seq[TweetFields] = Seq.empty[TweetFields],
+                                                   `user.fields`: Seq[UserFields] = Seq.empty[UserFields]) extends Parameters

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UsersByUsernamesParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UsersByUsernamesParameters.scala
@@ -1,0 +1,11 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.users.parameters
+
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.http.marshalling.Parameters
+
+private[twitter4s] final case class UsersByUsernamesParameters(usernames: Seq[String],
+                                                               expansions: Seq[Expansions],
+                                                               `tweet.fields`: Seq[TweetFields] = Seq.empty[TweetFields],
+                                                               `user.fields`: Seq[UserFields] = Seq.empty[UserFields]) extends Parameters

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UsersParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UsersParameters.scala
@@ -1,0 +1,11 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.users.parameters
+
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.http.marshalling.Parameters
+
+private[twitter4s] final case class UsersParameters(ids: Seq[String],
+                                                    expansions: Seq[Expansions],
+                                                    `tweet.fields`: Seq[TweetFields] = Seq.empty[TweetFields],
+                                                    `user.fields`: Seq[UserFields] = Seq.empty[UserFields]) extends Parameters

--- a/src/test/resources/twitter/rest/v2/users/userlookup/user.json
+++ b/src/test/resources/twitter/rest/v2/users/userlookup/user.json
@@ -1,0 +1,96 @@
+{
+  "data": {
+    "id": "6338724728067829004",
+    "name": "Shippy the Squirrel",
+    "username": "shippy",
+    "created_at": "2020-05-15T16:03:42.000Z",
+    "protected": false,
+    "location": "Seattle",
+    "url": "https://www.google.com/sodales",
+    "description": "Sed efficitur ultrices elit sed volutpat.",
+    "verified": true,
+    "entities": {
+      "url": {
+        "urls": [
+          {
+            "start": 257,
+            "end": 280,
+            "url": "https://t.co/sodales",
+            "expanded_url": "https://www.google.com/sodales",
+            "display_url": "example.google.com/sodales"
+          }
+        ]
+      },
+      "description": {
+        "urls": [
+          {
+            "start": 257,
+            "end": 280,
+            "url": "https://t.co/sodales",
+            "expanded_url": "https://www.google.com/sodales",
+            "display_url": "example.google.com/sodales"
+          }
+        ],
+        "mentions": [
+          {
+            "start": 105,
+            "end": 121,
+            "username": "SuspendisseAtNunc"
+          },
+          {
+            "start": 125,
+            "end": 138,
+            "username": "SuspendisseAtNuncPosuere"
+          }
+        ],
+        "hashtags": [
+          {
+            "start": 47,
+            "end": 60,
+            "tag": "SuspendisseAtNunc"
+          },
+          {
+            "start": 171,
+            "end": 194,
+            "tag": "SuspendisseNunc"
+          }
+        ],
+        "cashtags": [
+          {
+            "start": 41,
+            "end": 44,
+            "tag": "GE"
+          }
+        ]
+      }
+    },
+    "profile_image_url": "https://www.google.com/sodales.adri",
+    "public_metrics": {
+      "followers_count": 501796,
+      "following_count": 306,
+      "tweet_count": 6655,
+      "listed_count": 1433
+    },
+    "pinned_tweet_id": "2894469526322928935"
+  },
+  "includes": {
+    "users": [
+      {
+        "id": "3955854555026519618",
+        "name": "AliquamOrciEros",
+        "username": "aliquamorcieros"
+      },
+      {
+        "id": "6747736441958634428",
+        "name": "Suspendisse At Nunc",
+        "username": "suspendisseatnunc"
+      }
+    ],
+    "tweets": [
+      {
+        "id": "6304480225832455363",
+        "text": "Donec feugiat elit tellus, a ultrices elit sodales facilisis."
+      }
+    ]
+  }
+}

--- a/src/test/resources/twitter/rest/v2/users/userlookup/users.json
+++ b/src/test/resources/twitter/rest/v2/users/userlookup/users.json
@@ -1,0 +1,96 @@
+{
+  "data": [{
+    "id": "6338724728067829004",
+    "name": "Shippy the Squirrel",
+    "username": "shippy",
+    "created_at": "2020-05-15T16:03:42.000Z",
+    "protected": false,
+    "location": "Seattle",
+    "url": "https://www.google.com/sodales",
+    "description": "Sed efficitur ultrices elit sed volutpat.",
+    "verified": true,
+    "entities": {
+      "url": {
+        "urls": [
+          {
+            "start": 257,
+            "end": 280,
+            "url": "https://t.co/sodales",
+            "expanded_url": "https://www.google.com/sodales",
+            "display_url": "example.google.com/sodales"
+          }
+        ]
+      },
+      "description": {
+        "urls": [
+          {
+            "start": 257,
+            "end": 280,
+            "url": "https://t.co/sodales",
+            "expanded_url": "https://www.google.com/sodales",
+            "display_url": "example.google.com/sodales"
+          }
+        ],
+        "mentions": [
+          {
+            "start": 105,
+            "end": 121,
+            "username": "SuspendisseAtNunc"
+          },
+          {
+            "start": 125,
+            "end": 138,
+            "username": "SuspendisseAtNuncPosuere"
+          }
+        ],
+        "hashtags": [
+          {
+            "start": 47,
+            "end": 60,
+            "tag": "SuspendisseAtNunc"
+          },
+          {
+            "start": 171,
+            "end": 194,
+            "tag": "SuspendisseNunc"
+          }
+        ],
+        "cashtags": [
+          {
+            "start": 41,
+            "end": 44,
+            "tag": "GE"
+          }
+        ]
+      }
+    },
+    "profile_image_url": "https://www.google.com/sodales.adri",
+    "public_metrics": {
+      "followers_count": 501796,
+      "following_count": 306,
+      "tweet_count": 6655,
+      "listed_count": 1433
+    },
+    "pinned_tweet_id": "2894469526322928935"
+  }],
+  "includes": {
+    "users": [
+      {
+        "id": "3955854555026519618",
+        "name": "AliquamOrciEros",
+        "username": "aliquamorcieros"
+      },
+      {
+        "id": "6747736441958634428",
+        "name": "Suspendisse At Nunc",
+        "username": "suspendisseatnunc"
+      }
+    ],
+    "tweets": [
+      {
+        "id": "6304480225832455363",
+        "text": "Donec feugiat elit tellus, a ultrices elit sodales facilisis."
+      }
+    ]
+  }
+}

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/TweetResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/TweetResponseFixture.scala
@@ -150,7 +150,7 @@ object TweetResponseFixture {
       source = Some("Twitter for iPhone"),
       withheld = None
     )),
-    includes = Some(Includes(
+    includes = Some(TweetIncludes(
       tweets = Seq(Tweet(
         id = "6304480225832455363",
         text = "Donec feugiat elit tellus, a ultrices elit sodales facilisis.",

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/TweetsResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/TweetsResponseFixture.scala
@@ -149,7 +149,7 @@ object TweetsResponseFixture {
       source = Some("Twitter for iPhone"),
       withheld = None
     )),
-    includes = Some(Includes(
+    includes = Some(TweetIncludes(
       tweets = Seq(Tweet(
         id = "6304480225832455363",
         text = "Donec feugiat elit tellus, a ultrices elit sodales facilisis.",

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/TwitterUserLookupClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/TwitterUserLookupClientSpec.scala
@@ -1,0 +1,310 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.users
+
+import akka.http.scaladsl.model.HttpMethods
+import com.danielasfregola.twitter4s.entities.RatedData
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.{Expansions => UserExpansions}
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.entities.v2.responses.{UserResponse, UsersResponse}
+import com.danielasfregola.twitter4s.helpers.ClientSpec
+import com.danielasfregola.twitter4s.http.clients.rest.v2.users.fixtures.{UserResponseFixture, UsersResponseFixture}
+import com.danielasfregola.twitter4s.http.clients.rest.v2.utils.V2SpecQueryHelper
+
+class TwitterUserLookupClientSpec extends ClientSpec {
+
+  class TwitterUserLookupClientSpecContext extends RestClientSpecContext with TwitterUserLookupClient
+
+  "Twitter User Lookup Client" should {
+
+    "lookup users" in new TwitterUserLookupClientSpecContext {
+      val userIds = Seq("123","456")
+      val result: RatedData[UsersResponse] = when(lookupUsers(userIds))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === "https://api.twitter.com/2/users"
+          request.uri.rawQueryString === Some(V2SpecQueryHelper.buildIdsParam(userIds))
+        }
+        .respondWithRated("/twitter/rest/v2/users/userlookup/users.json")
+        .await
+      result.rate_limit === rateLimit
+      result.data === UsersResponseFixture.fixture
+    }
+
+    "lookup users with expansions" in new TwitterUserLookupClientSpecContext {
+      val userIds = Seq("123","456")
+      val expansions: Seq[UserExpansions] = V2SpecQueryHelper.allUserExpansions
+
+      when(lookupUsers(
+        ids = userIds,
+        expansions = expansions
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === "https://api.twitter.com/2/users"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildUserExpansions(expansions),
+            V2SpecQueryHelper.buildIdsParam(userIds)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup users with user fields" in new TwitterUserLookupClientSpecContext {
+      val userIds = Seq("123","456")
+      val userFields: Seq[UserFields] = V2SpecQueryHelper.allUserFields
+
+      when(lookupUsers(
+        ids = userIds,
+        userFields = userFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === "https://api.twitter.com/2/users"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildIdsParam(userIds),
+            V2SpecQueryHelper.buildUserFieldsParam(userFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup users with tweet fields" in new TwitterUserLookupClientSpecContext {
+      val userIds = Seq("123","456")
+      val tweetFields: Seq[TweetFields] = V2SpecQueryHelper.allTweetFields
+
+      when(lookupUsers(
+        ids = userIds,
+        tweetFields = tweetFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === "https://api.twitter.com/2/users"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildIdsParam(userIds),
+            V2SpecQueryHelper.buildTweetFieldsParam(tweetFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup user" in new TwitterUserLookupClientSpecContext {
+      val userId = "123"
+      val result: RatedData[UserResponse] = when(lookupUser(userId))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId"
+          request.uri.rawQueryString === None
+        }
+        .respondWithRated("/twitter/rest/v2/users/userlookup/user.json")
+        .await
+      result.rate_limit === rateLimit
+      result.data === UserResponseFixture.fixture
+    }
+
+    "lookup user with expansions" in new TwitterUserLookupClientSpecContext {
+      val userId = "123"
+      val expansions: Seq[UserExpansions] = V2SpecQueryHelper.allUserExpansions
+
+      when(lookupUser(
+        id = userId,
+        expansions = expansions
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildUserExpansions(expansions)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup user with user fields" in new TwitterUserLookupClientSpecContext {
+      val userId = "123"
+      val userFields: Seq[UserFields] = V2SpecQueryHelper.allUserFields
+
+      when(lookupUser(
+        id = userId,
+        userFields = userFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildUserFieldsParam(userFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup user with tweet fields" in new TwitterUserLookupClientSpecContext {
+      val userId = "123"
+      val tweetFields: Seq[TweetFields] = V2SpecQueryHelper.allTweetFields
+
+      when(lookupUser(
+        id = userId,
+        tweetFields = tweetFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildTweetFieldsParam(tweetFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup users by usernames" in new TwitterUserLookupClientSpecContext {
+      val usernames = Seq("user1","user2")
+      val result: RatedData[UsersResponse] = when(lookupUsersByUsernames(usernames))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === "https://api.twitter.com/2/users/by"
+          request.uri.rawQueryString === Some(V2SpecQueryHelper.buildUsernamesParam(usernames))
+        }
+        .respondWithRated("/twitter/rest/v2/users/userlookup/users.json")
+        .await
+      result.rate_limit === rateLimit
+      result.data === UsersResponseFixture.fixture
+    }
+
+    "lookup users by usernames with expansions" in new TwitterUserLookupClientSpecContext {
+      val usernames = Seq("user1","user2")
+      val expansions: Seq[UserExpansions] = V2SpecQueryHelper.allUserExpansions
+
+      when(lookupUsersByUsernames(
+        usernames = usernames,
+        expansions = expansions
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === "https://api.twitter.com/2/users/by"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildUserExpansions(expansions),
+            V2SpecQueryHelper.buildUsernamesParam(usernames)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup users by usernames with user fields" in new TwitterUserLookupClientSpecContext {
+      val usernames = Seq("user1","user2")
+      val userFields: Seq[UserFields] = V2SpecQueryHelper.allUserFields
+
+      when(lookupUsersByUsernames(
+        usernames = usernames,
+        userFields = userFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === "https://api.twitter.com/2/users/by"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildUserFieldsParam(userFields),
+            V2SpecQueryHelper.buildUsernamesParam(usernames)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup users by usernames with tweet fields" in new TwitterUserLookupClientSpecContext {
+      val usernames = Seq("user1","user2")
+      val tweetFields: Seq[TweetFields] = V2SpecQueryHelper.allTweetFields
+
+      when(lookupUsersByUsernames(
+        usernames = usernames,
+        tweetFields = tweetFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === "https://api.twitter.com/2/users/by"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildTweetFieldsParam(tweetFields),
+            V2SpecQueryHelper.buildUsernamesParam(usernames)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup user by username" in new TwitterUserLookupClientSpecContext {
+      val username = "user1"
+      val result: RatedData[UserResponse] = when(lookupUserByUsername(username))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/by/username/$username"
+          request.uri.rawQueryString === None
+        }
+        .respondWithRated("/twitter/rest/v2/users/userlookup/user.json")
+        .await
+      result.rate_limit === rateLimit
+      result.data === UserResponseFixture.fixture
+    }
+
+    "lookup user with expansions" in new TwitterUserLookupClientSpecContext {
+      val username = "user1"
+      val expansions: Seq[UserExpansions] = V2SpecQueryHelper.allUserExpansions
+
+      when(lookupUserByUsername(
+        username = username,
+        expansions = expansions
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/by/username/$username"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildUserExpansions(expansions)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup user by username with user fields" in new TwitterUserLookupClientSpecContext {
+      val username = "user1"
+      val userFields: Seq[UserFields] = V2SpecQueryHelper.allUserFields
+
+      when(lookupUserByUsername(
+        username = username,
+        userFields = userFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/by/username/$username"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildUserFieldsParam(userFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup user by username with tweet fields" in new TwitterUserLookupClientSpecContext {
+      val username = "user1"
+      val tweetFields: Seq[TweetFields] = V2SpecQueryHelper.allTweetFields
+
+      when(lookupUserByUsername(
+        username = username,
+        tweetFields = tweetFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/by/username/$username"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildTweetFieldsParam(tweetFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+  }
+}

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/fixtures/UserResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/fixtures/UserResponseFixture.scala
@@ -1,0 +1,142 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.users.fixtures
+
+import com.danielasfregola.twitter4s.entities.v2._
+import com.danielasfregola.twitter4s.entities.v2.responses.UserResponse
+import java.time.Instant
+
+object UserResponseFixture {
+  val fixture: UserResponse = UserResponse(
+    data = Some(User(
+      id = "6338724728067829004",
+      name = "Shippy the Squirrel",
+      username = "shippy",
+      created_at = Some(Instant.parse("2020-05-15T16:03:42.000Z")),
+      `protected` = Some(false),
+      location = Some("Seattle"),
+      url = Some("https://www.google.com/sodales"),
+      description = Some("Sed efficitur ultrices elit sed volutpat."),
+      verified = Some(true),
+      entities = Some(UserEntities(
+        url = Some(UserURLContainer(
+          urls = Seq(
+            UserEntitiesURL(
+              start = 257,
+              end = 280,
+              url = "https://t.co/sodales",
+              expanded_url = "https://www.google.com/sodales",
+              display_url = "example.google.com/sodales",
+            )
+          )
+        )),
+        description = Some(UserEntitiesDescription(
+          urls = Seq(
+            UserEntitiesURL(
+              start = 257,
+              end = 280,
+              url = "https://t.co/sodales",
+              expanded_url = "https://www.google.com/sodales",
+              display_url = "example.google.com/sodales",
+            )
+          ),
+          mentions = Seq(
+            UserEntitiesMention(
+              start = 105,
+              end = 121,
+              username = "SuspendisseAtNunc"
+            ),
+            UserEntitiesMention(
+              start = 125,
+              end = 138,
+              username = "SuspendisseAtNuncPosuere"
+            )
+          ),
+          hashtags = Seq(
+            UserEntitiesHashtag(
+              start = 47,
+              end = 60,
+              tag = "SuspendisseAtNunc"
+            ),
+            UserEntitiesHashtag(
+              start = 171,
+              end = 194,
+              tag = "SuspendisseNunc"
+            )
+          ),
+          cashtags = Seq(UserEntitiesCashtag(
+            start = 41,
+            end = 44,
+            tag = "GE"
+          ))
+        ))
+      )),
+      profile_image_url = Some("https://www.google.com/sodales.adri"),
+      public_metrics = Some(UserPublicMetrics(
+        followers_count = 501796,
+        following_count = 306,
+        tweet_count = 6655,
+        listed_count = 1433
+      )),
+      pinned_tweet_id = Some("2894469526322928935"),
+      withheld = None
+    )),
+    includes = Some(UserIncludes(
+      tweets = Seq(Tweet(
+        id = "6304480225832455363",
+        text = "Donec feugiat elit tellus, a ultrices elit sodales facilisis.",
+        attachments = None,
+        author_id = None,
+        context_annotations = None,
+        conversation_id = None,
+        created_at = None,
+        entities = None,
+        geo = None,
+        in_reply_to_user_id = None,
+        lang = None,
+        non_public_metrics = None,
+        organic_metrics = None,
+        possibly_sensitive = None,
+        promoted_metrics = None,
+        public_metrics = None,
+        referenced_tweets = None,
+        reply_settings = None,
+        source = None,
+        withheld = None
+      )),
+      users = Seq(
+        User(
+          id = "3955854555026519618",
+          name = "AliquamOrciEros",
+          username = "aliquamorcieros",
+          created_at = None,
+          `protected` = None,
+          withheld = None,
+          location = None,
+          url = None,
+          description = None,
+          verified = None,
+          entities = None,
+          profile_image_url = None,
+          public_metrics = None,
+          pinned_tweet_id = None
+        ),
+        User(
+          id = "6747736441958634428",
+          name = "Suspendisse At Nunc",
+          username = "suspendisseatnunc",
+          created_at = None,
+          `protected` = None,
+          withheld = None,
+          location = None,
+          url = None,
+          description = None,
+          verified = None,
+          entities = None,
+          profile_image_url = None,
+          public_metrics = None,
+          pinned_tweet_id = None
+        )
+      )
+    )),
+    errors = Seq.empty[Error]
+  )
+}

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/fixtures/UsersResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/fixtures/UsersResponseFixture.scala
@@ -1,0 +1,142 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.users.fixtures
+
+import com.danielasfregola.twitter4s.entities.v2.{Error, Tweet, User, UserEntities, UserEntitiesCashtag, UserEntitiesDescription, UserEntitiesHashtag, UserEntitiesMention, UserEntitiesURL, UserPublicMetrics, UserURLContainer, UserIncludes}
+import com.danielasfregola.twitter4s.entities.v2.responses.UsersResponse
+import java.time.Instant
+
+object UsersResponseFixture {
+  val fixture: UsersResponse = UsersResponse(
+    data = Seq(User(
+      id = "6338724728067829004",
+      name = "Shippy the Squirrel",
+      username = "shippy",
+      created_at = Some(Instant.parse("2020-05-15T16:03:42.000Z")),
+      `protected` = Some(false),
+      location = Some("Seattle"),
+      url = Some("https://www.google.com/sodales"),
+      description = Some("Sed efficitur ultrices elit sed volutpat."),
+      verified = Some(true),
+      entities = Some(UserEntities(
+        url = Some(UserURLContainer(
+          urls = Seq(
+            UserEntitiesURL(
+              start = 257,
+              end = 280,
+              url = "https://t.co/sodales",
+              expanded_url = "https://www.google.com/sodales",
+              display_url = "example.google.com/sodales",
+            )
+          )
+        )),
+        description = Some(UserEntitiesDescription(
+          urls = Seq(
+            UserEntitiesURL(
+              start = 257,
+              end = 280,
+              url = "https://t.co/sodales",
+              expanded_url = "https://www.google.com/sodales",
+              display_url = "example.google.com/sodales",
+            )
+          ),
+          mentions = Seq(
+            UserEntitiesMention(
+              start = 105,
+              end = 121,
+              username = "SuspendisseAtNunc"
+            ),
+            UserEntitiesMention(
+              start = 125,
+              end = 138,
+              username = "SuspendisseAtNuncPosuere"
+            )
+          ),
+          hashtags = Seq(
+            UserEntitiesHashtag(
+              start = 47,
+              end = 60,
+              tag = "SuspendisseAtNunc"
+            ),
+            UserEntitiesHashtag(
+              start = 171,
+              end = 194,
+              tag = "SuspendisseNunc"
+            )
+          ),
+          cashtags = Seq(UserEntitiesCashtag(
+            start = 41,
+            end = 44,
+            tag = "GE"
+          ))
+        ))
+      )),
+      profile_image_url = Some("https://www.google.com/sodales.adri"),
+      public_metrics = Some(UserPublicMetrics(
+        followers_count = 501796,
+        following_count = 306,
+        tweet_count = 6655,
+        listed_count = 1433
+      )),
+      pinned_tweet_id = Some("2894469526322928935"),
+      withheld = None
+    )),
+    includes = Some(UserIncludes(
+      tweets = Seq(Tweet(
+        id = "6304480225832455363",
+        text = "Donec feugiat elit tellus, a ultrices elit sodales facilisis.",
+        attachments = None,
+        author_id = None,
+        context_annotations = None,
+        conversation_id = None,
+        created_at = None,
+        entities = None,
+        geo = None,
+        in_reply_to_user_id = None,
+        lang = None,
+        non_public_metrics = None,
+        organic_metrics = None,
+        possibly_sensitive = None,
+        promoted_metrics = None,
+        public_metrics = None,
+        referenced_tweets = None,
+        reply_settings = None,
+        source = None,
+        withheld = None
+      )),
+      users = Seq(
+        User(
+          id = "3955854555026519618",
+          name = "AliquamOrciEros",
+          username = "aliquamorcieros",
+          created_at = None,
+          `protected` = None,
+          withheld = None,
+          location = None,
+          url = None,
+          description = None,
+          verified = None,
+          entities = None,
+          profile_image_url = None,
+          public_metrics = None,
+          pinned_tweet_id = None
+        ),
+        User(
+          id = "6747736441958634428",
+          name = "Suspendisse At Nunc",
+          username = "suspendisseatnunc",
+          created_at = None,
+          `protected` = None,
+          withheld = None,
+          location = None,
+          url = None,
+          description = None,
+          verified = None,
+          entities = None,
+          profile_image_url = None,
+          public_metrics = None,
+          pinned_tweet_id = None
+        )
+      )
+    )),
+    errors = Seq.empty[Error]
+  )
+}

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/utils/V2SpecQueryHelper.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/utils/V2SpecQueryHelper.scala
@@ -1,0 +1,66 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.utils
+
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.{Expansions => UserExpansions}
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.{TweetFields, UserFields}
+import java.net.URLEncoder
+
+private[v2] object V2SpecQueryHelper {
+  val allUserExpansions: Seq[UserExpansions] = Seq(
+    UserExpansions.PinnedTweetId
+  )
+
+  val allTweetFields: Seq[TweetFields] = Seq(
+    TweetFields.Attachments,
+    TweetFields.AuthorId,
+    TweetFields.ContextAnnotations,
+    TweetFields.ConversationId,
+    TweetFields.CreatedAt,
+    TweetFields.Entities,
+    TweetFields.Geo,
+    TweetFields.Id,
+    TweetFields.InReplyToUserId,
+    TweetFields.Lang,
+    TweetFields.NonPublicMetrics,
+    TweetFields.PublicMetrics,
+    TweetFields.OrganicMetrics,
+    TweetFields.PromotedMetrics,
+    TweetFields.PossiblySensitive,
+    TweetFields.ReferencedTweets,
+    TweetFields.ReplySettings,
+    TweetFields.Source,
+    TweetFields.Text,
+    TweetFields.Withheld
+  )
+
+  val allUserFields: Seq[UserFields] = Seq(
+    UserFields.CreatedAt,
+    UserFields.Description,
+    UserFields.Entities,
+    UserFields.Id,
+    UserFields.Location,
+    UserFields.Name,
+    UserFields.PinnedTweetId,
+    UserFields.ProfileImageUrl,
+    UserFields.Protected,
+    UserFields.PublicMetrics,
+    UserFields.Url,
+    UserFields.Username,
+    UserFields.Verified,
+    UserFields.Withheld
+  )
+
+  def buildIdsParam(ids: Seq[String]): String = "ids=" + encodeQueryParamValue(ids.mkString(","))
+  def buildUsernamesParam(usernames: Seq[String]): String = "usernames=" + encodeQueryParamKey(usernames.mkString(","))
+
+  def buildUserExpansions(expansions: Seq[UserExpansions]): String = "expansions=" + encodeQueryParamValue(expansions.mkString(","))
+
+  def buildTweetFieldsParam(fields: Seq[TweetFields]): String = encodeQueryParamKey("tweet.fields") + "=" + encodeQueryParamValue(fields.mkString(","))
+
+  def buildUserFieldsParam(fields: Seq[UserFields]): String = encodeQueryParamKey("user.fields") + "=" + encodeQueryParamValue(fields.mkString(","))
+
+  private def encodeQueryParamKey(str: String) = URLEncoder.encode(str, "UTF-8").replace(".","%2E")
+  private def encodeQueryParamValue(str: String) = URLEncoder.encode(str, "UTF-8")
+}


### PR DESCRIPTION
This PR adds full support for the [User Lookup](https://developer.twitter.com/en/docs/twitter-api/users/lookup/introduction) endpoints under Twitter's new V2 API. 

The user based endpoints are being built with Tweet materialization permitted. Likewise, with the addition of this user model, the Tweet endpoints can be updated to permit User materialization. However, to cut down on PR complexity, these changes will be included in a separate PR. 