### PR TITLE
User Fields available on Tweet Lookup

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/TweetIncludes.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/TweetIncludes.scala
@@ -1,7 +1,7 @@
 package com.danielasfregola.twitter4s.entities.v2
 
-final case class TweetIncludes(tweets: Seq[Tweet]
-                               // users: Seq[User], // TODO: Pending addition of users model
+final case class TweetIncludes(tweets: Seq[Tweet],
+                               users: Seq[User]
                                // places: Seq[Place], // TODO: Pending addition of places model
                                // media: Seq[Media], // TODO: Pending addition of media model
                                // polls: Seq[Polls] // TODO pending addition of polls model

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/expansions/TweetExpansions.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/expansions/TweetExpansions.scala
@@ -5,7 +5,7 @@ object TweetExpansions extends Enumeration {
 
   // val `Attachments.PollIds` = Value("attachments.poll_ids") // TODO: Pending addition of poll model
   // val `Attachments.MediaKeys` = Value("attachments.media_keys") // TODO: Pending addition of media model
-  // val AuthorId = Value("author_id") // TODO: Pending addition of user model
+  val AuthorId = Value("author_id")
   val `Entities.Mentions.Username` = Value("entities.mentions.username")
   //  val `Geo.PlaceId` = Value("geo.place_id") // TODO: Pending addition of place model
   val InReplyToUser = Value("in_reply_to_user_id")

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTweetLookupClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTweetLookupClient.scala
@@ -41,12 +41,19 @@ trait TwitterTweetLookupClient {
     *                    to return the specified fields for both the original Tweet and any included referenced Tweets.
     *                    The requested Tweet fields will display in both the original Tweet data object, as well as in
     *                    the referenced Tweet expanded data object that will be located in the includes data object.
+    * @param userFields  : Optional, by default is `Seq.empty`
+    *                    This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                    enables you to select which specific
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user">user fields</a>
+    *                    will deliver in each returned Tweet. While the user ID will be located in the original Tweet object,
+    *                    you will find this ID and all additional user fields in the includes data object.
     *
     * @return : The representation of the search results.
     */
   def lookupTweets(ids: Seq[String],
                    expansions: Seq[Expansions] = Seq.empty[Expansions],
-                   tweetFields: Seq[TweetFields] = Seq.empty[TweetFields]): Future[RatedData[TweetsResponse]] = {
+                   tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
+                   userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[TweetsResponse]] = {
     val parameters = TweetsParameters(
       ids,
       expansions,
@@ -54,7 +61,7 @@ trait TwitterTweetLookupClient {
       Seq.empty[PlaceFields], // TODO: Pending addition of place model
       Seq.empty[PollFields], // TODO: Pending addition of poll model
       tweetFields,
-      Seq.empty[UserFields] // TODO: Pending addition of user model
+      userFields
     )
 
     genericGetTweets(parameters)
@@ -80,19 +87,26 @@ trait TwitterTweetLookupClient {
     *                    to return the specified fields for both the original Tweet and any included referenced Tweets.
     *                    The requested Tweet fields will display in both the original Tweet data object, as well as in
     *                    the referenced Tweet expanded data object that will be located in the includes data object.
+    * @param userFields  : Optional, by default is `Seq.empty`
+    *                    This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                    enables you to select which specific
+    *                    <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user">user fields</a>
+    *                    will deliver in each returned Tweet. While the user ID will be located in the original Tweet object,
+    *                    you will find this ID and all additional user fields in the includes data object.
     *
     * @return : The representation of the tweet.
     */
   def lookupTweet(id: String,
                   expansions: Seq[Expansions] = Seq.empty[Expansions],
-                  tweetFields: Seq[TweetFields] = Seq.empty[TweetFields]): Future[RatedData[TweetResponse]] = {
+                  tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
+                  userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[TweetResponse]] = {
     val parameters = TweetParameters(
       expansions,
       Seq.empty[MediaFields], // TODO: Pending addition of media model
       Seq.empty[PlaceFields], // TODO: Pending addition of place model
       Seq.empty[PollFields], // TODO: Pending addition of poll model
       tweetFields,
-      Seq.empty[UserFields] // TODO: Pending addition of user model
+      userFields
     )
 
     genericGetTweet(

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTweetLookupClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTweetLookupClientSpec.scala
@@ -2,11 +2,10 @@ package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets
 
 import akka.http.scaladsl.model.HttpMethods
 import com.danielasfregola.twitter4s.entities.RatedData
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions
-import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields
 import com.danielasfregola.twitter4s.entities.v2.responses.{TweetResponse, TweetsResponse}
 import com.danielasfregola.twitter4s.helpers.ClientSpec
 import com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.fixtures.{TweetResponseFixture, TweetsResponseFixture}
+import com.danielasfregola.twitter4s.http.clients.rest.v2.utils.V2SpecQueryHelper
 
 class TwitterTweetLookupClientSpec extends ClientSpec {
 
@@ -15,11 +14,12 @@ class TwitterTweetLookupClientSpec extends ClientSpec {
   "Twitter Tweet Lookup Client" should {
 
     "lookup tweets" in new TwitterTweetLookupClientSpecContext {
-      val result: RatedData[TweetsResponse] = when(lookupTweets(Seq("123", "456")))
+      val tweetIds = Seq("123", "456")
+      val result: RatedData[TweetsResponse] = when(lookupTweets(tweetIds))
         .expectRequest { request =>
           request.method === HttpMethods.GET
           request.uri.endpoint === "https://api.twitter.com/2/tweets"
-          request.uri.rawQueryString === Some("ids=123%2C456")
+          request.uri.rawQueryString === Some(V2SpecQueryHelper.buildIdsParam(tweetIds))
         }
         .respondWithRated("/twitter/rest/v2/tweets/tweetlookup/tweets.json")
         .await
@@ -29,70 +29,62 @@ class TwitterTweetLookupClientSpec extends ClientSpec {
 
     "lookup tweets with expansions" in new TwitterTweetLookupClientSpecContext {
       val tweetIds = Seq("123", "456")
-      val expansions = Seq(
-        TweetExpansions.`Entities.Mentions.Username`,
-        TweetExpansions.InReplyToUser,
-        TweetExpansions.`ReferencedTweets.Id`,
-        TweetExpansions.`ReferencedTweets.Id.AuthorId`
-      )
+      val expansions = V2SpecQueryHelper.allTweetExpansions
 
-      val result: RatedData[TweetsResponse] = when(lookupTweets(
+      when(lookupTweets(
         ids = tweetIds,
         expansions = expansions
       ))
         .expectRequest { request =>
           request.method === HttpMethods.GET
           request.uri.endpoint === "https://api.twitter.com/2/tweets"
-          request.uri.rawQueryString === Some(
-            "expansions=entities.mentions.username%2Cin_reply_to_user_id%2Creferenced_tweets.id%2Creferenced_tweets.id.author_id&ids=123%2C456"
-          )
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildTweetExpansions(expansions),
+            V2SpecQueryHelper.buildIdsParam(tweetIds)
+          ).mkString("&"))
         }
-        .respondWithRated("/twitter/rest/v2/tweets/tweetlookup/tweets.json")
+        .respondWithOk
         .await
-      result.rate_limit === rateLimit
-      result.data === TweetsResponseFixture.fixture
     }
 
     "lookup tweets with tweet fields" in new TwitterTweetLookupClientSpecContext {
       val tweetIds = Seq("123", "456")
-      val tweetFields = Seq(
-        TweetFields.Attachments,
-        TweetFields.AuthorId,
-        TweetFields.ContextAnnotations,
-        TweetFields.ConversationId,
-        TweetFields.CreatedAt,
-        TweetFields.Entities,
-        TweetFields.Geo,
-        TweetFields.Id,
-        TweetFields.InReplyToUserId,
-        TweetFields.Lang,
-        TweetFields.NonPublicMetrics,
-        TweetFields.PublicMetrics,
-        TweetFields.OrganicMetrics,
-        TweetFields.PromotedMetrics,
-        TweetFields.PossiblySensitive,
-        TweetFields.ReferencedTweets,
-        TweetFields.ReplySettings,
-        TweetFields.Source,
-        TweetFields.Text,
-        TweetFields.Withheld
-      )
+      val tweetFields = V2SpecQueryHelper.allTweetFields
 
-      val result: RatedData[TweetsResponse] = when(lookupTweets(
+      when(lookupTweets(
         ids = tweetIds,
         tweetFields = tweetFields
       ))
         .expectRequest { request =>
           request.method === HttpMethods.GET
           request.uri.endpoint === "https://api.twitter.com/2/tweets"
-          request.uri.rawQueryString === Some(
-            "ids=123%2C456&tweet%2Efields=attachments%2Cauthor_id%2Ccontext_annotations%2Cconversation_id%2Ccreated_at%2Centities%2Cgeo%2Cid%2Cin_reply_to_user_id%2Clang%2Cnon_public_metrics%2Cpublic_metrics%2Corganic_metrics%2Cpromoted_metrics%2Cpossibly_sensitive%2Creferenced_tweets%2Creply_settings%2Csource%2Ctext%2Cwithheld"
-          )
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildIdsParam(tweetIds),
+            V2SpecQueryHelper.buildTweetFieldsParam(tweetFields)
+          ).mkString("&"))
         }
-        .respondWithRated("/twitter/rest/v2/tweets/tweetlookup/tweets.json")
+        .respondWithOk
         .await
-      result.rate_limit === rateLimit
-      result.data === TweetsResponseFixture.fixture
+    }
+
+    "lookup tweets with user fields" in new TwitterTweetLookupClientSpecContext {
+      val tweetIds = Seq("123", "456")
+      val userFields = V2SpecQueryHelper.allUserFields
+
+      when(lookupTweets(
+        ids = tweetIds,
+        userFields = userFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === "https://api.twitter.com/2/tweets"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildIdsParam(tweetIds),
+            V2SpecQueryHelper.buildUserFieldsParam(userFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
     }
 
     "lookup tweet" in new TwitterTweetLookupClientSpecContext {
@@ -110,70 +102,53 @@ class TwitterTweetLookupClientSpec extends ClientSpec {
 
     "lookup tweet with expansions" in new TwitterTweetLookupClientSpecContext {
       val tweetId = "123"
-      val expansions = Seq(
-        TweetExpansions.`Entities.Mentions.Username`,
-        TweetExpansions.InReplyToUser,
-        TweetExpansions.`ReferencedTweets.Id`,
-        TweetExpansions.`ReferencedTweets.Id.AuthorId`
-      )
+      val expansions = V2SpecQueryHelper.allTweetExpansions
 
-      val result: RatedData[TweetResponse] = when(lookupTweet(
+      when(lookupTweet(
         id = tweetId,
         expansions = expansions
       ))
         .expectRequest { request =>
           request.method === HttpMethods.GET
           request.uri.endpoint === s"https://api.twitter.com/2/tweets/$tweetId"
-          request.uri.rawQueryString === Some(
-            "expansions=entities.mentions.username%2Cin_reply_to_user_id%2Creferenced_tweets.id%2Creferenced_tweets.id.author_id"
-          )
+          request.uri.rawQueryString === Some(V2SpecQueryHelper.buildTweetExpansions(expansions))
         }
-        .respondWithRated("/twitter/rest/v2/tweets/tweetlookup/tweet.json")
+        .respondWithOk
         .await
-      result.rate_limit === rateLimit
-      result.data === TweetResponseFixture.fixture
     }
 
     "lookup tweet with tweet fields" in new TwitterTweetLookupClientSpecContext {
       val tweetId = "123"
-      val tweetFields = Seq(
-        TweetFields.Attachments,
-        TweetFields.AuthorId,
-        TweetFields.ContextAnnotations,
-        TweetFields.ConversationId,
-        TweetFields.CreatedAt,
-        TweetFields.Entities,
-        TweetFields.Geo,
-        TweetFields.Id,
-        TweetFields.InReplyToUserId,
-        TweetFields.Lang,
-        TweetFields.NonPublicMetrics,
-        TweetFields.PublicMetrics,
-        TweetFields.OrganicMetrics,
-        TweetFields.PromotedMetrics,
-        TweetFields.PossiblySensitive,
-        TweetFields.ReferencedTweets,
-        TweetFields.ReplySettings,
-        TweetFields.Source,
-        TweetFields.Text,
-        TweetFields.Withheld
-      )
+      val tweetFields = V2SpecQueryHelper.allTweetFields
 
-      val result: RatedData[TweetResponse] = when(lookupTweet(
+      when(lookupTweet(
         id = tweetId,
         tweetFields = tweetFields
       ))
         .expectRequest { request =>
           request.method === HttpMethods.GET
           request.uri.endpoint === s"https://api.twitter.com/2/tweets/$tweetId"
-          request.uri.rawQueryString === Some(
-            "tweet%2Efields=attachments%2Cauthor_id%2Ccontext_annotations%2Cconversation_id%2Ccreated_at%2Centities%2Cgeo%2Cid%2Cin_reply_to_user_id%2Clang%2Cnon_public_metrics%2Cpublic_metrics%2Corganic_metrics%2Cpromoted_metrics%2Cpossibly_sensitive%2Creferenced_tweets%2Creply_settings%2Csource%2Ctext%2Cwithheld"
-          )
+          request.uri.rawQueryString === Some(V2SpecQueryHelper.buildTweetFieldsParam(tweetFields))
         }
-        .respondWithRated("/twitter/rest/v2/tweets/tweetlookup/tweet.json")
+        .respondWithOk
         .await
-      result.rate_limit === rateLimit
-      result.data === TweetResponseFixture.fixture
+    }
+
+    "lookup tweet with user fields" in new TwitterTweetLookupClientSpecContext {
+      val tweetId = "123"
+      val userFields = V2SpecQueryHelper.allUserFields
+
+      when(lookupTweet(
+        id = tweetId,
+        userFields = userFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/tweets/$tweetId"
+          request.uri.rawQueryString === Some(V2SpecQueryHelper.buildUserFieldsParam(userFields))
+        }
+        .respondWithOk
+        .await
     }
   }
 }

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/TweetResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/TweetResponseFixture.scala
@@ -172,7 +172,41 @@ object TweetResponseFixture {
         reply_settings = None,
         source = None,
         withheld = None
-      ))
+      )),
+      users = Seq(
+        User(
+          id = "3955854555026519618",
+          name = "AliquamOrciEros",
+          username = "aliquamorcieros",
+          created_at = None,
+          `protected` = None,
+          withheld = None,
+          location = None,
+          url = None,
+          description = None,
+          verified = None,
+          entities = None,
+          profile_image_url = None,
+          public_metrics = None,
+          pinned_tweet_id = None
+        ),
+        User(
+          id = "6747736441958634428",
+          name = "Suspendisse At Nunc",
+          username = "suspendisseatnunc",
+          created_at = None,
+          `protected` = None,
+          withheld = None,
+          location = None,
+          url = None,
+          description = None,
+          verified = None,
+          entities = None,
+          profile_image_url = None,
+          public_metrics = None,
+          pinned_tweet_id = None
+        )
+      )
     )),
     errors = Seq.empty[Error]
   )

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/TweetsResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/TweetsResponseFixture.scala
@@ -171,7 +171,41 @@ object TweetsResponseFixture {
         reply_settings = None,
         source = None,
         withheld = None
-      ))
+      )),
+      users = Seq(
+        User(
+          id = "3955854555026519618",
+          name = "AliquamOrciEros",
+          username = "aliquamorcieros",
+          created_at = None,
+          `protected` = None,
+          withheld = None,
+          location = None,
+          url = None,
+          description = None,
+          verified = None,
+          entities = None,
+          profile_image_url = None,
+          public_metrics = None,
+          pinned_tweet_id = None
+        ),
+        User(
+          id = "6747736441958634428",
+          name = "Suspendisse At Nunc",
+          username = "suspendisseatnunc",
+          created_at = None,
+          `protected` = None,
+          withheld = None,
+          location = None,
+          url = None,
+          description = None,
+          verified = None,
+          entities = None,
+          profile_image_url = None,
+          public_metrics = None,
+          pinned_tweet_id = None
+        )
+      )
     )),
     errors = Seq.empty[Error]
   )

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/utils/V2SpecQueryHelper.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/utils/V2SpecQueryHelper.scala
@@ -1,5 +1,7 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.utils
 
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.{Expansions => TweetExpansions}
 import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.{Expansions => UserExpansions}
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
@@ -8,6 +10,14 @@ import com.danielasfregola.twitter4s.entities.v2.enums.fields.{TweetFields, User
 import java.net.URLEncoder
 
 private[v2] object V2SpecQueryHelper {
+  val allTweetExpansions: Seq[TweetExpansions] = Seq(
+    TweetExpansions.AuthorId,
+    TweetExpansions.`Entities.Mentions.Username`,
+    TweetExpansions.InReplyToUser,
+    TweetExpansions.`ReferencedTweets.Id`,
+    TweetExpansions.`ReferencedTweets.Id.AuthorId`
+  )
+
   val allUserExpansions: Seq[UserExpansions] = Seq(
     UserExpansions.PinnedTweetId
   )
@@ -55,6 +65,7 @@ private[v2] object V2SpecQueryHelper {
   def buildIdsParam(ids: Seq[String]): String = "ids=" + encodeQueryParamValue(ids.mkString(","))
   def buildUsernamesParam(usernames: Seq[String]): String = "usernames=" + encodeQueryParamKey(usernames.mkString(","))
 
+  def buildTweetExpansions(expansions: Seq[TweetExpansions]): String = "expansions=" + encodeQueryParamValue(expansions.mkString(","))
   def buildUserExpansions(expansions: Seq[UserExpansions]): String = "expansions=" + encodeQueryParamValue(expansions.mkString(","))
 
   def buildTweetFieldsParam(fields: Seq[TweetFields]): String = encodeQueryParamKey("tweet.fields") + "=" + encodeQueryParamValue(fields.mkString(","))


### PR DESCRIPTION
A short and sweet pr which allows for user fields to be queried by the tweet lookup endpoints. 