### PR TITLE
Create TwitterTimelinesClient

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/TwitterRestV2Client.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/TwitterRestV2Client.scala
@@ -3,7 +3,7 @@ package com.danielasfregola.twitter4s
 import akka.actor.ActorSystem
 import com.danielasfregola.twitter4s.entities.{AccessToken, ConsumerToken}
 import com.danielasfregola.twitter4s.http.clients.rest.RestClient
-import com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.TwitterTweetLookupClient
+import com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.{TwitterTimelinesClient, TwitterTweetLookupClient}
 import com.danielasfregola.twitter4s.http.clients.rest.v2.users.TwitterUserLookupClient
 import com.danielasfregola.twitter4s.util.Configurations._
 import com.danielasfregola.twitter4s.util.SystemShutdown
@@ -22,8 +22,9 @@ class TwitterRestV2Client(val consumerToken: ConsumerToken, val accessToken: Acc
 }
 
 trait V2RestClients
-  extends TwitterTweetLookupClient
-  with TwitterUserLookupClient
+  extends TwitterTimelinesClient
+    with TwitterTweetLookupClient
+    with TwitterUserLookupClient
 
 object TwitterRestV2Client {
 

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/Meta.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/Meta.scala
@@ -1,0 +1,7 @@
+package com.danielasfregola.twitter4s.entities.v2
+
+final case class Meta(result_count: Int,
+                      newest_id: Option[String],
+                      oldest_id: Option[String],
+                      next_token: Option[String],
+                      previous_token: Option[String])

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/rest/TimelineExclude.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/rest/TimelineExclude.scala
@@ -1,0 +1,8 @@
+package com.danielasfregola.twitter4s.entities.v2.enums.rest
+
+object TimelineExclude extends Enumeration {
+  type TimelineExclude = Value
+
+  val Retweets = Value("retweets")
+  val Replies = Value("replies")
+}

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/responses/TweetsResponse.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/responses/TweetsResponse.scala
@@ -1,7 +1,8 @@
 package com.danielasfregola.twitter4s.entities.v2.responses
 
-import com.danielasfregola.twitter4s.entities.v2.{Error, TweetIncludes, Tweet}
+import com.danielasfregola.twitter4s.entities.v2.{Error, Meta, Tweet, TweetIncludes}
 
 final case class TweetsResponse(data: Seq[Tweet],
                                 includes: Option[TweetIncludes],
+                                meta: Option[Meta],
                                 errors: Seq[Error])

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTimelinesClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTimelinesClient.scala
@@ -1,0 +1,261 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets
+
+import com.danielasfregola.twitter4s.entities.RatedData
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.PlaceFields.PlaceFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.PollFields.PollFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.entities.v2.enums.rest.TimelineExclude.TimelineExclude
+import com.danielasfregola.twitter4s.entities.v2.responses.TweetsResponse
+import com.danielasfregola.twitter4s.http.clients.rest.RestClient
+import com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.paramaters.{TimelineMentionsParameters, TimelineTweetsParameters}
+import com.danielasfregola.twitter4s.util.Configurations.{apiTwitterUrl, twitterVersionV2}
+import java.time.Instant
+
+import scala.concurrent.Future
+
+/** Implements the available requests for the v2 `timelines` resource. */
+trait TwitterTimelinesClient {
+
+  protected val restClient: RestClient
+
+  private val baseTimelinesUrl = s"$apiTwitterUrl/$twitterVersionV2/users"
+
+  /** Returns Tweets composed by a single user, specified by the requested user ID.
+    * By default, the most recent ten Tweets are returned per request. Using pagination, the most recent 3,200 Tweets
+    * can be retrieved.
+    *
+    * The Tweets returned by this endpoint count towards the Project-level
+    * <a href="https://developer.twitter.com/en/docs/projects/overview#tweet-cap" target="_blank">
+    * Tweet cap</a>.
+    *
+    * For more information see
+    * <a href="https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets" target="_blank">
+    * https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets</a>
+    *
+    * @param userId          : Unique identifier of the Twitter account (user ID) for whom to return results.
+    *                        User ID can be referenced using the
+    *                        <a href="https://developer.twitter.com/en/docs/twitter-api/users/lookup/introduction" target="_blank">
+    *                        user/lookup</a> endpoint.
+    *                        More information on Twitter IDs is
+    *                        <a href="https://developer.twitter.com/en/docs/twitter-ids" target="_blank">
+    *                        here</a>.
+    * @param startTime       : Optional, by default is `None`
+    *                        The oldest or earliest UTC timestamp from which the Tweets will be provided. Only the 3200 most
+    *                        recent Tweets are available. Timestamp is in second granularity and is inclusive
+    *                        (for example, 12:00:01 includes the first second of the minute).
+    *                        Minimum allowable time is 2010-11-06T00:00:00Z
+    *
+    *                        Please note that this parameter does not support a millisecond value.
+    * @param endTime         : Optional, by default is `None`
+    *                        The newest or most recent UTC timestamp from which the Tweets will be provided. Only the 3200
+    *                        most recent Tweets are available. Timestamp is in second granularity and is inclusive
+    *                        (for example, 12:00:01 includes the first second of the minute).
+    *                        Minimum allowable time is 2010-11-06T00:00:01Z
+    *
+    *                        Please note that this parameter does not support a millisecond value.
+    * @param maxResults      : Optional, by default is `None`
+    *                        Specifies the number of Tweets to try and retrieve, up to a maximum of 100 per distinct request.
+    *                        By default, 10 results are returned if this parameter is not supplied. The minimum permitted
+    *                        value is 5. It is possible to receive less than the `max_results` per request throughout the
+    *                        pagination process.
+    * @param paginationToken : Optional, by default is `None`
+    *                        This parameter is used to move forwards or backwards through 'pages' of results, based on
+    *                        the value of the `next_token` or `previous_token` in the response. The value used with the
+    *                        parameter is pulled directly from the response provided by the API, and should not be modified.
+    * @param sinceId         : Optional, by default is `None`
+    *                        Returns results with a Tweet ID greater than (that is, more recent than) the specified
+    *                        'since' Tweet ID. Only the 3200 most recent Tweets are available. The result will exclude
+    *                        the `since_id`. If the limit of Tweets has occurred since the `since_id`,
+    *                        the `since_id` will be forced to the oldest ID available.
+    * @param untilId         : Optional, by default is `None`
+    *                        Returns results with a Tweet ID less less than (that is, older than) the specified 'until'
+    *                        Tweet ID. Only the 3200 most recent Tweets are available. The result will exclude the
+    *                        `until_id`. If the limit of Tweets has occurred since the `until_id`, the `until_id` will be
+    *                        forced to the most recent ID available.
+    * @param exclude         : Optional, by default is `Seq.empty`
+    *                        List of the types of Tweets to exclude from the response. When `exclude=retweets` is used,
+    *                        the maximum historical Tweets returned is still 3200. When the `exclude=replies` parameter
+    *                        is used for any value, only the most recent 800 Tweets are available.
+    * @param expansions      : Optional, by default is `Seq.empty`
+    *                        Expansions enable you to request additional data objects that relate to the originally
+    *                        returned Tweets. The ID that represents the expanded data object will be included directly
+    *                        in the Tweet data object, but the expanded object metadata will be returned within the includes
+    *                        response object, and will also include the ID so that you can match this data object to the
+    *                        original Tweet object.
+    * @param tweetFields     : Optional, by default is `Seq.empty`
+    *                        This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                        enables you to select which specific
+    *                        <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet">Tweet fields</a>
+    *                        will deliver in each returned Tweet object. You can also include the `referenced_tweets.id` expansion
+    *                        to return the specified fields for both the original Tweet and any included referenced Tweets.
+    *                        The requested Tweet fields will display in both the original Tweet data object, as well as in
+    *                        the referenced Tweet expanded data object that will be located in the includes data object.
+    * @param userFields      : Optional, by default is `Seq.empty`
+    *                        This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                        enables you to select which specific
+    *                        <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user">user fields</a>
+    *                        will deliver in each returned Tweet. While the user ID will be located in the original Tweet object,
+    *                        you will find this ID and all additional user fields in the includes data object.
+    *
+    * @return : The representation of the search results.
+    */
+  def lookupTimeline(userId: String,
+                     startTime: Option[Instant] = None,
+                     endTime: Option[Instant] = None,
+                     maxResults: Option[Int] = None,
+                     paginationToken: Option[String] = None,
+                     sinceId: Option[String] = None,
+                     untilId: Option[String] = None,
+                     exclude: Seq[TimelineExclude] = Seq.empty[TimelineExclude],
+                     expansions: Seq[Expansions] = Seq.empty[Expansions],
+                     tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
+                     userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[TweetsResponse]] = {
+    val parameters = TimelineTweetsParameters(
+      start_time = startTime,
+      end_time = endTime,
+      max_results = maxResults,
+      pagination_token = paginationToken,
+      since_id = sinceId,
+      until_id = untilId,
+      exclude = exclude,
+      expansions = expansions,
+      `media.fields` = Seq.empty[MediaFields], // TODO: Pending addition of media model
+      `place.fields` = Seq.empty[PlaceFields], // TODO: Pending addition of place model
+      `poll.fields` = Seq.empty[PollFields], // TODO: Pending addition of poll fields
+      `tweet.fields` = tweetFields,
+      `user.fields` = userFields
+    )
+
+    genericGetTweets(
+      userId,
+      parameters
+    )
+  }
+
+  /** Returns Tweets mentioning a single user specified by the requested user ID. By default, the most recent ten
+    * Tweets are returned per request. Using pagination, up to the most recent 800 Tweets can be retrieved.
+    *
+    * The Tweets returned by this endpoint count towards the Project-level
+    * <a href="https://developer.twitter.com/en/docs/projects/overview#tweet-cap" target="_blank">
+    * Tweet cap</a>.
+    *
+    * For more information see
+    * <a href="https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets" target="_blank">
+    * https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets</a>
+    *
+    * @param userId          : Unique identifier of the Twitter account (user ID) for whom to return results.
+    *                        User ID can be referenced using the
+    *                        <a href="https://developer.twitter.com/en/docs/twitter-api/users/lookup/introduction" target="_blank">
+    *                        user/lookup</a> endpoint.
+    *                        More information on Twitter IDs is
+    *                        <a href="https://developer.twitter.com/en/docs/twitter-ids" target="_blank">
+    *                        here</a>.
+    * @param startTime       : Optional, by default is `None`
+    *                        The oldest or earliest UTC timestamp from which the Tweets will be provided. Only the 3200 most
+    *                        recent Tweets are available. Timestamp is in second granularity and is inclusive
+    *                        (for example, 12:00:01 includes the first second of the minute).
+    *                        Minimum allowable time is 2010-11-06T00:00:00Z
+    *
+    *                        Please note that this parameter does not support a millisecond value.
+    * @param endTime         : Optional, by default is `None`
+    *                        The newest or most recent UTC timestamp from which the Tweets will be provided. Only the 3200
+    *                        most recent Tweets are available. Timestamp is in second granularity and is inclusive
+    *                        (for example, 12:00:01 includes the first second of the minute).
+    *                        Minimum allowable time is 2010-11-06T00:00:01Z
+    *
+    *                        Please note that this parameter does not support a millisecond value.
+    * @param maxResults      : Optional, by default is `None`
+    *                        Specifies the number of Tweets to try and retrieve, up to a maximum of 100 per distinct request.
+    *                        By default, 10 results are returned if this parameter is not supplied. The minimum permitted
+    *                        value is 5. It is possible to receive less than the `max_results` per request throughout the
+    *                        pagination process.
+    * @param paginationToken : Optional, by default is `None`
+    *                        This parameter is used to move forwards or backwards through 'pages' of results, based on
+    *                        the value of the `next_token` or `previous_token` in the response. The value used with the
+    *                        parameter is pulled directly from the response provided by the API, and should not be modified.
+    * @param sinceId         : Optional, by default is `None`
+    *                        Returns results with a Tweet ID greater than (that is, more recent than) the specified
+    *                        'since' Tweet ID. Only the 3200 most recent Tweets are available. The result will exclude
+    *                        the `since_id`. If the limit of Tweets has occurred since the `since_id`,
+    *                        the `since_id` will be forced to the oldest ID available.
+    * @param untilId         : Optional, by default is `None`
+    *                        Returns results with a Tweet ID less less than (that is, older than) the specified 'until'
+    *                        Tweet ID. Only the 3200 most recent Tweets are available. The result will exclude the
+    *                        `until_id`. If the limit of Tweets has occurred since the `until_id`, the `until_id` will be
+    *                        forced to the most recent ID available.
+    * @param expansions      : Optional, by default is `Seq.empty`
+    *                        Expansions enable you to request additional data objects that relate to the originally
+    *                        returned Tweets. The ID that represents the expanded data object will be included directly
+    *                        in the Tweet data object, but the expanded object metadata will be returned within the includes
+    *                        response object, and will also include the ID so that you can match this data object to the
+    *                        original Tweet object.
+    * @param tweetFields     : Optional, by default is `Seq.empty`
+    *                        This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                        enables you to select which specific
+    *                        <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet">Tweet fields</a>
+    *                        will deliver in each returned Tweet object. You can also include the `referenced_tweets.id` expansion
+    *                        to return the specified fields for both the original Tweet and any included referenced Tweets.
+    *                        The requested Tweet fields will display in both the original Tweet data object, as well as in
+    *                        the referenced Tweet expanded data object that will be located in the includes data object.
+    * @param userFields      : Optional, by default is `Seq.empty`
+    *                        This <a href="https://developer.twitter.com/en/docs/twitter-api/fields">fields</a> parameter
+    *                        enables you to select which specific
+    *                        <a href="https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/user">user fields</a>
+    *                        will deliver in each returned Tweet. While the user ID will be located in the original Tweet object,
+    *                        you will find this ID and all additional user fields in the includes data object.
+    *
+    * @return : The representation of the search results.
+    */
+  def lookupMentions(userId: String,
+                     startTime: Option[Instant] = None,
+                     endTime: Option[Instant] = None,
+                     maxResults: Option[Int] = None,
+                     paginationToken: Option[String] = None,
+                     sinceId: Option[String] = None,
+                     untilId: Option[String] = None,
+                     expansions: Seq[Expansions] = Seq.empty[Expansions],
+                     tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
+                     userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[TweetsResponse]] = {
+    val parameters = TimelineMentionsParameters(
+      start_time = startTime,
+      end_time = endTime,
+      max_results = maxResults,
+      pagination_token = paginationToken,
+      since_id = sinceId,
+      until_id = untilId,
+      expansions = expansions,
+      `media.fields` = Seq.empty[MediaFields], // TODO: Pending addition of media model
+      `place.fields` = Seq.empty[PlaceFields], // TODO: Pending addition of place model
+      `poll.fields` = Seq.empty[PollFields], // TODO: Pending addition of poll fields
+      `tweet.fields` = tweetFields,
+      `user.fields` = userFields
+    )
+
+    genericGetMentions(
+      userId,
+      parameters
+    )
+  }
+
+
+  private def genericGetTweets(userId: String, parameters: TimelineTweetsParameters): Future[RatedData[TweetsResponse]] = {
+    import restClient._
+
+    Get(
+      s"$baseTimelinesUrl/$userId/tweets",
+      parameters
+    ).respondAsRated[TweetsResponse]
+  }
+
+  private def genericGetMentions(userId: String, parameters: TimelineMentionsParameters): Future[RatedData[TweetsResponse]] = {
+    import restClient._
+
+    Get(
+      s"$baseTimelinesUrl/$userId/mentions",
+      parameters
+    ).respondAsRated[TweetsResponse]
+  }
+}

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TimelineMentionsParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TimelineMentionsParameters.scala
@@ -1,0 +1,23 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.paramaters
+
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.PlaceFields.PlaceFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.PollFields.PollFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.http.marshalling.Parameters
+import java.time.Instant
+
+private[twitter4s] final case class TimelineMentionsParameters(end_time: Option[Instant] = None,
+                                                               expansions: Seq[Expansions] = Seq.empty[Expansions],
+                                                               max_results: Option[Int] = None,
+                                                               `media.fields`: Seq[MediaFields] = Seq.empty[MediaFields],
+                                                               pagination_token: Option[String] = None,
+                                                               `place.fields`: Seq[PlaceFields] = Seq.empty[PlaceFields],
+                                                               `poll.fields`: Seq[PollFields] = Seq.empty[PollFields],
+                                                               since_id: Option[String] = None,
+                                                               start_time: Option[Instant] = None,
+                                                               `tweet.fields`: Seq[TweetFields] = Seq.empty[TweetFields],
+                                                               until_id: Option[String] = None,
+                                                               `user.fields`: Seq[UserFields] = Seq.empty[UserFields]) extends Parameters

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TimelineTweetsParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TimelineTweetsParameters.scala
@@ -1,0 +1,25 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.paramaters
+
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.PlaceFields.PlaceFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.PollFields.PollFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.entities.v2.enums.rest.TimelineExclude.TimelineExclude
+import com.danielasfregola.twitter4s.http.marshalling.Parameters
+import java.time.Instant
+
+private[twitter4s] final case class TimelineTweetsParameters(end_time: Option[Instant] = None,
+                                                             exclude: Seq[TimelineExclude] = Seq.empty[TimelineExclude],
+                                                             expansions: Seq[Expansions] = Seq.empty[Expansions],
+                                                             max_results: Option[Int] = None,
+                                                             `media.fields`: Seq[MediaFields] = Seq.empty[MediaFields],
+                                                             pagination_token: Option[String] = None,
+                                                             `place.fields`: Seq[PlaceFields] = Seq.empty[PlaceFields],
+                                                             `poll.fields`: Seq[PollFields] = Seq.empty[PollFields],
+                                                             since_id: Option[String] = None,
+                                                             start_time: Option[Instant] = None,
+                                                             `tweet.fields`: Seq[TweetFields] = Seq.empty[TweetFields],
+                                                             until_id: Option[String] = None,
+                                                             `user.fields`: Seq[UserFields] = Seq.empty[UserFields]) extends Parameters

--- a/src/test/resources/twitter/rest/v2/tweets/timelines/tweets.json
+++ b/src/test/resources/twitter/rest/v2/tweets/timelines/tweets.json
@@ -1,0 +1,229 @@
+{
+  "data": [
+    {
+      "id": "2310484964373377688",
+      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+      "attachments": {
+        "media_keys": [
+          "13_9995568729608410852",
+          "14_0381608460867506993"
+        ],
+        "poll_ids": [
+          "0419198663175162881"
+        ]
+      },
+      "author_id": "6338724728067829004",
+      "context_annotations": [
+        {
+          "domain": {
+            "id": "10",
+            "name": "Person",
+            "description": "Vestibulum pellentesque sed justo ac lacinia"
+          },
+          "entity": {
+            "id": "5233852574321016658",
+            "name": "Phasellus Eu",
+            "description": "Phasellus Eu"
+          }
+        },
+        {
+          "domain": {
+            "id": "54",
+            "name": "Musician",
+            "description": "Nullam imperdiet lectus metus"
+          },
+          "entity": {
+            "id": "6836362243680041612",
+            "name": "Phasellus Eu",
+            "description": "Phasellus Eu"
+          }
+        }
+      ],
+      "conversation_id": "0471114572504780656",
+      "created_at": "2020-05-15T16:03:42.000Z",
+      "entities": {
+        "annotations": [
+          {
+            "start": 144,
+            "end": 150,
+            "probability": 0.626,
+            "type": "Product",
+            "normalized_text": "Twitter"
+          }
+        ],
+        "cashtags": [
+          {
+            "start": 41,
+            "end": 44,
+            "tag": "GE"
+          }
+        ],
+        "urls": [
+          {
+            "start": 257,
+            "end": 280,
+            "url": "https://t.co/sodales",
+            "expanded_url": "https://www.google.com/sodales",
+            "display_url": "example.google.com/sodales",
+            "images": [
+              {
+                "url": "https://www.google.com/sodales",
+                "width": 1200,
+                "height": 630
+              },
+              {
+                "url": "https://www.google.com/sodales",
+                "width": 150,
+                "height": 150
+              }
+            ],
+            "status": 200,
+            "title": "Ut eros tellus, rhoncus maximus lacus a, dictum rhoncus libero",
+            "description": "Sed efficitur ultrices elit sed volutpat. Cras nibh turpis, accumsan sed ultricies eget, egestas in libero. Suspendisse potenti. Nullam in posuere metus. Sed ut fringilla tortor",
+            "unwound_url": "https://www.google.com/sodales"
+          }
+        ],
+        "mentions": [
+          {
+            "start": 105,
+            "end": 121,
+            "username": "SuspendisseAtNunc",
+            "id": "2894469526322928935"
+          },
+          {
+            "start": 125,
+            "end": 138,
+            "username": "SuspendisseAtNuncPosuere",
+            "id": "6279687081065223918"
+          }
+        ],
+        "hashtags": [
+          {
+            "start": 47,
+            "end": 60,
+            "tag": "SuspendisseAtNunc"
+          },
+          {
+            "start": 171,
+            "end": 194,
+            "tag": "SuspendisseNunc"
+          }
+        ]
+      },
+      "geo": {
+        "coordinates": {
+          "type": "Point",
+          "coordinates": [
+            40.74118764,
+            -73.9998279
+          ]
+        },
+        "place_id": "0fc2bbe1f995b733"
+      },
+      "in_reply_to_user_id": "1600750904601052113",
+      "lang": "en",
+      "non_public_metrics": {
+        "user_profile_clicks": 0,
+        "impression_count": 29,
+        "url_link_clicks": 12
+      },
+      "organic_metrics": {
+        "retweet_count": 0,
+        "url_link_clicks": 12,
+        "reply_count": 0,
+        "like_count": 1,
+        "user_profile_clicks": 0,
+        "impression_count": 29
+      },
+      "possibly_sensitive": true,
+      "promoted_metrics": {
+        "impression_count": 29,
+        "url_link_clicks": 12,
+        "user_profile_clicks": 0,
+        "retweet_count": 0,
+        "reply_count": 0,
+        "like_count": 1
+      },
+      "public_metrics": {
+        "retweet_count": 0,
+        "reply_count": 0,
+        "like_count": 1,
+        "quote_count": 0
+      },
+      "referenced_tweets": [
+        {
+          "type": "retweeted",
+          "id": "4653693971459419590"
+        }
+      ],
+      "reply_settings": "everyone",
+      "source": "Twitter for iPhone"
+    }
+  ],
+  "meta": {
+    "oldest_id": "1356759580211109999",
+    "newest_id": "1410697282811569999",
+    "result_count": 7,
+    "next_token": "123"
+  },
+  "includes": {
+    "users": [
+      {
+        "id": "3955854555026519618",
+        "name": "AliquamOrciEros",
+        "username": "aliquamorcieros"
+      },
+      {
+        "id": "6747736441958634428",
+        "name": "Suspendisse At Nunc",
+        "username": "suspendisseatnunc"
+      }
+    ],
+    "tweets": [
+      {
+        "id": "6304480225832455363",
+        "text": "Donec feugiat elit tellus, a ultrices elit sodales facilisis."
+      }
+    ],
+    "polls": [
+      {
+        "id": "0425105815647696196",
+        "options": [
+          {
+            "position": 1,
+            "label": "Hulu",
+            "votes": 9
+          },
+          {
+            "position": 2,
+            "label": "Netflix",
+            "votes": 26
+          },
+          {
+            "position": 3,
+            "label": "Amazon Prime",
+            "votes": 3
+          },
+          {
+            "position": 4,
+            "label": "YouTube TV",
+            "votes": 3
+          }
+        ]
+      }
+    ],
+    "media": [
+      {
+        "height": 1280,
+        "media_key": "7_8340593532515834174",
+        "type": "video"
+      }
+    ],
+    "places": [
+      {
+        "full_name": "Curabitur ultrices ut odio ac pretium",
+        "id": "0fc2bbe1f995b733"
+      }
+    ]
+  }
+}

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTimelinesClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTimelinesClientSpec.scala
@@ -1,0 +1,183 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets
+
+import akka.http.scaladsl.model.HttpMethods
+import com.danielasfregola.twitter4s.entities.RatedData
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.{Expansions => TweetExpansions}
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
+import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
+import com.danielasfregola.twitter4s.entities.v2.enums.rest.TimelineExclude
+import com.danielasfregola.twitter4s.entities.v2.enums.rest.TimelineExclude.TimelineExclude
+import com.danielasfregola.twitter4s.entities.v2.responses.TweetsResponse
+import com.danielasfregola.twitter4s.helpers.ClientSpec
+import com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.fixtures.timelines.TweetsResponseFixture
+import com.danielasfregola.twitter4s.http.clients.rest.v2.utils.V2SpecQueryHelper
+
+class TwitterTimelinesClientSpec extends ClientSpec {
+
+  class TwitterTimelinesClientSpecContext extends RestClientSpecContext with TwitterTimelinesClient
+
+  "Twitter Tweet Lookup Client" should {
+
+    "lookup timelines" in new TwitterTimelinesClientSpecContext {
+      val userId = "123"
+      val result: RatedData[TweetsResponse] = when(lookupTimeline(userId))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId/tweets"
+          request.uri.rawQueryString === None
+        }
+        .respondWithRated("/twitter/rest/v2/tweets/timelines/tweets.json")
+        .await
+      result.rate_limit === rateLimit
+      result.data === TweetsResponseFixture.fixture
+    }
+
+    "lookup timelines with expansions" in new TwitterTimelinesClientSpecContext {
+      val userId = "123"
+      val expansions: Seq[TweetExpansions] = V2SpecQueryHelper.allTweetExpansions
+
+      when(lookupTimeline(
+        userId = userId,
+        expansions = expansions
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId/tweets"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildTweetExpansions(expansions)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup timelines with exclude" in new TwitterTimelinesClientSpecContext {
+      val userId = "123"
+      val exclusions: Seq[TimelineExclude] = Seq(
+        TimelineExclude.Replies,
+        TimelineExclude.Retweets
+      )
+
+      when(lookupTimeline(
+        userId = userId,
+        exclude = exclusions
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId/tweets"
+          request.uri.rawQueryString === Some("exclude=replies%2Cretweets")
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup timelines with tweet fields" in new TwitterTimelinesClientSpecContext {
+      val userId = "123"
+      val tweetFields: Seq[TweetFields] = V2SpecQueryHelper.allTweetFields
+
+      when(lookupTimeline(
+        userId = userId,
+        tweetFields = tweetFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId/tweets"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildTweetFieldsParam(tweetFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup timelines with user fields" in new TwitterTimelinesClientSpecContext {
+      val userId = "123"
+      val userFields: Seq[UserFields] = V2SpecQueryHelper.allUserFields
+
+      when(lookupTimeline(
+        userId = userId,
+        userFields = userFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId/tweets"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildUserFieldsParam(userFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup mentions" in new TwitterTimelinesClientSpecContext {
+      val userId = "123"
+      val result: RatedData[TweetsResponse] = when(lookupMentions(userId))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId/mentions"
+          request.uri.rawQueryString === None
+        }
+        .respondWithRated("/twitter/rest/v2/tweets/timelines/tweets.json")
+        .await
+      result.rate_limit === rateLimit
+      result.data === TweetsResponseFixture.fixture
+    }
+
+    "lookup mentions with expansions" in new TwitterTimelinesClientSpecContext {
+      val userId = "123"
+      val expansions: Seq[TweetExpansions] = V2SpecQueryHelper.allTweetExpansions
+
+      when(lookupMentions(
+        userId = userId,
+        expansions = expansions
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId/mentions"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildTweetExpansions(expansions)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup mentions with tweet fields" in new TwitterTimelinesClientSpecContext {
+      val userId = "123"
+      val tweetFields: Seq[TweetFields] = V2SpecQueryHelper.allTweetFields
+
+      when(lookupMentions(
+        userId = userId,
+        tweetFields = tweetFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId/mentions"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildTweetFieldsParam(tweetFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+
+    "lookup mentions with user fields" in new TwitterTimelinesClientSpecContext {
+      val userId = "123"
+      val userFields: Seq[UserFields] = V2SpecQueryHelper.allUserFields
+
+      when(lookupMentions(
+        userId = userId,
+        userFields = userFields
+      ))
+        .expectRequest { request =>
+          request.method === HttpMethods.GET
+          request.uri.endpoint === s"https://api.twitter.com/2/users/$userId/mentions"
+          request.uri.rawQueryString === Some(Seq(
+            V2SpecQueryHelper.buildUserFieldsParam(userFields)
+          ).mkString("&"))
+        }
+        .respondWithOk
+        .await
+    }
+  }
+}

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTweetLookupClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTweetLookupClientSpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.HttpMethods
 import com.danielasfregola.twitter4s.entities.RatedData
 import com.danielasfregola.twitter4s.entities.v2.responses.{TweetResponse, TweetsResponse}
 import com.danielasfregola.twitter4s.helpers.ClientSpec
-import com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.fixtures.{TweetResponseFixture, TweetsResponseFixture}
+import com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.fixtures.tweet_lookup.{TweetResponseFixture, TweetsResponseFixture}
 import com.danielasfregola.twitter4s.http.clients.rest.v2.utils.V2SpecQueryHelper
 
 class TwitterTweetLookupClientSpec extends ClientSpec {

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/timelines/TweetsResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/timelines/TweetsResponseFixture.scala
@@ -1,0 +1,219 @@
+package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.fixtures.timelines
+
+import com.danielasfregola.twitter4s.entities.v2._
+import com.danielasfregola.twitter4s.entities.v2.enums.{CoordinatesType, ReferencedTweetType, TweetReplySetting}
+import com.danielasfregola.twitter4s.entities.v2.responses.TweetsResponse
+import java.time.Instant
+
+object TweetsResponseFixture {
+  val fixture: TweetsResponse = TweetsResponse(
+    data = Seq(Tweet(
+      id = "2310484964373377688",
+      text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+      attachments = Some(TweetAttachments(
+        media_keys = Seq(
+          "13_9995568729608410852",
+          "14_0381608460867506993"
+        ),
+        poll_ids = Seq(
+          "0419198663175162881"
+        )
+      )),
+      author_id = Some("6338724728067829004"),
+      context_annotations = Some(Seq(
+        TweetContextAnnotation(
+          domain = TweetDomain(
+            id = "10",
+            name = "Person",
+            description = Some("Vestibulum pellentesque sed justo ac lacinia")
+          ),
+          entity = TweetEntity(
+            id = "5233852574321016658",
+            name = "Phasellus Eu",
+            description = Some("Phasellus Eu")
+          )
+        ),
+        TweetContextAnnotation(
+          domain = TweetDomain(
+            id = "54",
+            name = "Musician",
+            description = Some("Nullam imperdiet lectus metus")
+          ),
+          entity = TweetEntity(
+            id = "6836362243680041612",
+            name = "Phasellus Eu",
+            description = Some("Phasellus Eu")
+          )
+        )
+      )),
+      conversation_id = Some("0471114572504780656"),
+      created_at = Some(Instant.parse("2020-05-15T16:03:42.000Z")),
+      entities = Some(TweetEntities(
+        annotations = Seq(
+          TweetEntitiesAnnotation(
+            start = 144,
+            end = 150,
+            probability = 0.626f,
+            `type` = "Product",
+            normalized_text = "Twitter"
+          )
+        ),
+        cashtags = Seq(
+          TweetEntitiesCashtag(
+            start = 41,
+            end = 44,
+            tag = "GE"
+          )
+        ),
+        urls = Seq(
+          TweetEntitiesURL(
+            start = 257,
+            end = 280,
+            url = "https://t.co/sodales",
+            expanded_url = "https://www.google.com/sodales",
+            display_url = "example.google.com/sodales",
+            unwound_url = Some("https://www.google.com/sodales")
+          ),
+        ),
+        mentions = Seq(
+          TweetEntitiesMention(
+            start = 105,
+            end = 121,
+            username = Some("SuspendisseAtNunc"),
+            id = Some("2894469526322928935")
+          ),
+          TweetEntitiesMention(
+            start = 125,
+            end = 138,
+            username = Some("SuspendisseAtNuncPosuere"),
+            id = Some("6279687081065223918")
+          )
+        ),
+        hashtags = Seq(
+          TweetEntitiesHashtag(
+            start = 47,
+            end = 60,
+            tag = "SuspendisseAtNunc"
+          ),
+          TweetEntitiesHashtag(
+            start = 171,
+            end = 194,
+            tag = "SuspendisseNunc"
+          )
+        ),
+      )),
+      geo = Some(TweetGeo(
+        coordinates = Some(TweetCoordinates(
+          `type` = CoordinatesType.Point,
+          coordinates = (40.74118764, -73.9998279)
+        )),
+        place_id = Some("0fc2bbe1f995b733")
+      )),
+      in_reply_to_user_id = Some("1600750904601052113"),
+      lang = Some("en"),
+      non_public_metrics = Some(TweetNonPublicMetrics(
+        user_profile_clicks = 0,
+        impression_count = 29,
+        url_link_clicks = Some(12)
+      )),
+      organic_metrics = Some(TweetOrganicMetrics(
+        retweet_count = 0,
+        url_link_clicks = Some(12),
+        reply_count = 0,
+        like_count = 1,
+        user_profile_clicks = 0,
+        impression_count = 29
+      )),
+      possibly_sensitive = Some(true),
+      promoted_metrics = Some(TweetPromotedMetrics(
+        impression_count = 29,
+        url_link_clicks = Some(12),
+        user_profile_clicks = 0,
+        retweet_count = 0,
+        reply_count = 0,
+        like_count = 1
+      )),
+      public_metrics = Some(TweetPublicMetrics(
+        retweet_count = 0,
+        reply_count = 0,
+        like_count = 1,
+        quote_count = 0
+      )),
+      referenced_tweets = Some(Seq(
+        TweetReferencedTweet(
+          `type` = ReferencedTweetType.Retweeted,
+          id = "4653693971459419590"
+        )
+      )),
+      reply_settings = Some(TweetReplySetting.Everyone),
+      source = Some("Twitter for iPhone"),
+      withheld = None
+    )),
+    includes = Some(TweetIncludes(
+      tweets = Seq(Tweet(
+        id = "6304480225832455363",
+        text = "Donec feugiat elit tellus, a ultrices elit sodales facilisis.",
+        attachments = None,
+        author_id = None,
+        context_annotations = None,
+        conversation_id = None,
+        created_at = None,
+        entities = None,
+        geo = None,
+        in_reply_to_user_id = None,
+        lang = None,
+        non_public_metrics = None,
+        organic_metrics = None,
+        possibly_sensitive = None,
+        promoted_metrics = None,
+        public_metrics = None,
+        referenced_tweets = None,
+        reply_settings = None,
+        source = None,
+        withheld = None
+      )),
+      users = Seq(
+        User(
+          id = "3955854555026519618",
+          name = "AliquamOrciEros",
+          username = "aliquamorcieros",
+          created_at = None,
+          `protected` = None,
+          withheld = None,
+          location = None,
+          url = None,
+          description = None,
+          verified = None,
+          entities = None,
+          profile_image_url = None,
+          public_metrics = None,
+          pinned_tweet_id = None
+        ),
+        User(
+          id = "6747736441958634428",
+          name = "Suspendisse At Nunc",
+          username = "suspendisseatnunc",
+          created_at = None,
+          `protected` = None,
+          withheld = None,
+          location = None,
+          url = None,
+          description = None,
+          verified = None,
+          entities = None,
+          profile_image_url = None,
+          public_metrics = None,
+          pinned_tweet_id = None
+        )
+      )
+    )),
+    meta = Some(Meta(
+      oldest_id = Some("1356759580211109999"),
+      newest_id = Some("1410697282811569999"),
+      result_count = 7,
+      next_token = Some("123"),
+      previous_token = None
+    )),
+    errors = Seq.empty[Error]
+  )
+}

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/tweet_lookup/TweetResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/tweet_lookup/TweetResponseFixture.scala
@@ -1,10 +1,9 @@
-package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.fixtures
-
-import java.time.Instant
+package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.fixtures.tweet_lookup
 
 import com.danielasfregola.twitter4s.entities.v2._
-import com.danielasfregola.twitter4s.entities.v2.enums._
+import com.danielasfregola.twitter4s.entities.v2.enums.{CoordinatesType, ReferencedTweetType, TweetReplySetting}
 import com.danielasfregola.twitter4s.entities.v2.responses.TweetResponse
+import java.time.Instant
 
 object TweetResponseFixture {
   val fixture: TweetResponse = TweetResponse(

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/tweet_lookup/TweetsResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/fixtures/tweet_lookup/TweetsResponseFixture.scala
@@ -1,4 +1,4 @@
-package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.fixtures
+package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.fixtures.tweet_lookup
 
 import com.danielasfregola.twitter4s.entities.v2._
 import com.danielasfregola.twitter4s.entities.v2.enums.{CoordinatesType, ReferencedTweetType, TweetReplySetting}
@@ -207,6 +207,7 @@ object TweetsResponseFixture {
         )
       )
     )),
+    meta = None,
     errors = Seq.empty[Error]
   )
 }

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/TwitterUserLookupClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/TwitterUserLookupClientSpec.scala
@@ -7,7 +7,7 @@ import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetF
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
 import com.danielasfregola.twitter4s.entities.v2.responses.{UserResponse, UsersResponse}
 import com.danielasfregola.twitter4s.helpers.ClientSpec
-import com.danielasfregola.twitter4s.http.clients.rest.v2.users.fixtures.{UserResponseFixture, UsersResponseFixture}
+import com.danielasfregola.twitter4s.http.clients.rest.v2.users.fixtures.user_lookup.{UserResponseFixture, UsersResponseFixture}
 import com.danielasfregola.twitter4s.http.clients.rest.v2.utils.V2SpecQueryHelper
 
 class TwitterUserLookupClientSpec extends ClientSpec {

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/fixtures/user_lookup/UserResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/fixtures/user_lookup/UserResponseFixture.scala
@@ -1,4 +1,4 @@
-package com.danielasfregola.twitter4s.http.clients.rest.v2.users.fixtures
+package com.danielasfregola.twitter4s.http.clients.rest.v2.users.fixtures.user_lookup
 
 import com.danielasfregola.twitter4s.entities.v2._
 import com.danielasfregola.twitter4s.entities.v2.responses.UserResponse

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/fixtures/user_lookup/UsersResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/fixtures/user_lookup/UsersResponseFixture.scala
@@ -1,6 +1,6 @@
-package com.danielasfregola.twitter4s.http.clients.rest.v2.users.fixtures
+package com.danielasfregola.twitter4s.http.clients.rest.v2.users.fixtures.user_lookup
 
-import com.danielasfregola.twitter4s.entities.v2.{Error, Tweet, User, UserEntities, UserEntitiesCashtag, UserEntitiesDescription, UserEntitiesHashtag, UserEntitiesMention, UserEntitiesURL, UserPublicMetrics, UserURLContainer, UserIncludes}
+import com.danielasfregola.twitter4s.entities.v2._
 import com.danielasfregola.twitter4s.entities.v2.responses.UsersResponse
 import java.time.Instant
 


### PR DESCRIPTION
This PR adds support for querying [Timelines](https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/introduction). While these endpoints query a "/user" based URL, the resulting object is a list of Tweets. Because of this Twitter has categorized them as a Tweet endpoint and I've followed suit.

New endpoints:
- [GET /2/users/:id/tweets](https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets)
- [GET /2/users/:id/mentions ](https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-mentions)