### PR TITLE
Explicitly name Tweet and User expansions

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/expansions/TweetExpansions.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/expansions/TweetExpansions.scala
@@ -1,7 +1,7 @@
 package com.danielasfregola.twitter4s.entities.v2.enums.expansions
 
 object TweetExpansions extends Enumeration {
-  type Expansions = Value
+  type TweetExpansions = Value
 
   // val `Attachments.PollIds` = Value("attachments.poll_ids") // TODO: Pending addition of poll model
   val `Attachments.MediaKeys` = Value("attachments.media_keys")

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/expansions/UserExpansions.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/expansions/UserExpansions.scala
@@ -1,7 +1,7 @@
 package com.danielasfregola.twitter4s.entities.v2.enums.expansions
 
 object UserExpansions extends Enumeration {
-  type Expansions = Value
+  type UserExpansions = Value
 
   val PinnedTweetId = Value("pinned_tweet_id")
 }

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTimelinesClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTimelinesClient.scala
@@ -1,7 +1,7 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets
 
 import com.danielasfregola.twitter4s.entities.RatedData
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.TweetExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PlaceFields.PlaceFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PollFields.PollFields
@@ -115,7 +115,7 @@ trait TwitterTimelinesClient {
                      sinceId: Option[String] = None,
                      untilId: Option[String] = None,
                      exclude: Seq[TimelineExclude] = Seq.empty[TimelineExclude],
-                     expansions: Seq[Expansions] = Seq.empty[Expansions],
+                     expansions: Seq[TweetExpansions] = Seq.empty[TweetExpansions],
                      mediaFields: Seq[MediaFields] = Seq.empty[MediaFields],
                      tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
                      userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[TweetsResponse]] = {
@@ -222,7 +222,7 @@ trait TwitterTimelinesClient {
                      paginationToken: Option[String] = None,
                      sinceId: Option[String] = None,
                      untilId: Option[String] = None,
-                     expansions: Seq[Expansions] = Seq.empty[Expansions],
+                     expansions: Seq[TweetExpansions] = Seq.empty[TweetExpansions],
                      mediaFields: Seq[MediaFields] = Seq.empty[MediaFields],
                      tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
                      userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[TweetsResponse]] = {

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTweetLookupClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTweetLookupClient.scala
@@ -1,7 +1,7 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets
 
 import com.danielasfregola.twitter4s.entities.RatedData
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.TweetExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PlaceFields.PlaceFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PollFields.PollFields
@@ -51,7 +51,7 @@ trait TwitterTweetLookupClient {
     * @return : The representation of the search results.
     */
   def lookupTweets(ids: Seq[String],
-                   expansions: Seq[Expansions] = Seq.empty[Expansions],
+                   expansions: Seq[TweetExpansions] = Seq.empty[TweetExpansions],
                    mediaFields: Seq[MediaFields] = Seq.empty[MediaFields],
                    tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
                    userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[TweetsResponse]] = {
@@ -98,7 +98,7 @@ trait TwitterTweetLookupClient {
     * @return : The representation of the tweet.
     */
   def lookupTweet(id: String,
-                  expansions: Seq[Expansions] = Seq.empty[Expansions],
+                  expansions: Seq[TweetExpansions] = Seq.empty[TweetExpansions],
                   mediaFields: Seq[MediaFields] = Seq.empty[MediaFields],
                   tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
                   userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[TweetResponse]] = {

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TimelineMentionsParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TimelineMentionsParameters.scala
@@ -1,6 +1,6 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.paramaters
 
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.TweetExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PlaceFields.PlaceFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PollFields.PollFields
@@ -10,7 +10,7 @@ import com.danielasfregola.twitter4s.http.marshalling.Parameters
 import java.time.Instant
 
 private[twitter4s] final case class TimelineMentionsParameters(end_time: Option[Instant] = None,
-                                                               expansions: Seq[Expansions] = Seq.empty[Expansions],
+                                                               expansions: Seq[TweetExpansions] = Seq.empty[TweetExpansions],
                                                                max_results: Option[Int] = None,
                                                                `media.fields`: Seq[MediaFields] = Seq.empty[MediaFields],
                                                                pagination_token: Option[String] = None,

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TimelineTweetsParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TimelineTweetsParameters.scala
@@ -1,6 +1,6 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.paramaters
 
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.TweetExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PlaceFields.PlaceFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PollFields.PollFields
@@ -12,7 +12,7 @@ import java.time.Instant
 
 private[twitter4s] final case class TimelineTweetsParameters(end_time: Option[Instant] = None,
                                                              exclude: Seq[TimelineExclude] = Seq.empty[TimelineExclude],
-                                                             expansions: Seq[Expansions] = Seq.empty[Expansions],
+                                                             expansions: Seq[TweetExpansions] = Seq.empty[TweetExpansions],
                                                              max_results: Option[Int] = None,
                                                              `media.fields`: Seq[MediaFields] = Seq.empty[MediaFields],
                                                              pagination_token: Option[String] = None,

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TweetParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TweetParameters.scala
@@ -1,6 +1,6 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.paramaters
 
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.TweetExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PlaceFields.PlaceFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PollFields.PollFields
@@ -8,7 +8,7 @@ import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetF
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
 import com.danielasfregola.twitter4s.http.marshalling.Parameters
 
-private[twitter4s] final case class TweetParameters(expansions: Seq[Expansions] = Seq.empty[Expansions],
+private[twitter4s] final case class TweetParameters(expansions: Seq[TweetExpansions] = Seq.empty[TweetExpansions],
                                                     `media.fields`: Seq[MediaFields] = Seq.empty[MediaFields],
                                                     `place.fields`: Seq[PlaceFields] = Seq.empty[PlaceFields],
                                                     `poll.fields`: Seq[PollFields] = Seq.empty[PollFields],

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TweetsParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/paramaters/TweetsParameters.scala
@@ -1,6 +1,6 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.paramaters
 
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.TweetExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PlaceFields.PlaceFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.PollFields.PollFields
@@ -9,7 +9,7 @@ import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFie
 import com.danielasfregola.twitter4s.http.marshalling.Parameters
 
 private[twitter4s] final case class TweetsParameters(ids: Seq[String],
-                                                     expansions: Seq[Expansions] = Seq.empty[Expansions],
+                                                     expansions: Seq[TweetExpansions] = Seq.empty[TweetExpansions],
                                                      `media.fields`: Seq[MediaFields] = Seq.empty[MediaFields],
                                                      `place.fields`: Seq[PlaceFields] = Seq.empty[PlaceFields],
                                                      `poll.fields`: Seq[PollFields] = Seq.empty[PollFields],

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/TwitterUserLookupClient.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/TwitterUserLookupClient.scala
@@ -1,7 +1,7 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.users
 
 import com.danielasfregola.twitter4s.entities.RatedData
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.UserExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
 import com.danielasfregola.twitter4s.entities.v2.responses.{UserResponse, UsersResponse}
@@ -49,7 +49,7 @@ trait TwitterUserLookupClient {
     * @return : The representation of the search results.
     */
   def lookupUsers(ids: Seq[String],
-                  expansions: Seq[Expansions] = Seq.empty[Expansions],
+                  expansions: Seq[UserExpansions] = Seq.empty[UserExpansions],
                   tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
                   userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[UsersResponse]] = {
     import restClient._
@@ -98,7 +98,7 @@ trait TwitterUserLookupClient {
     * @return : The representation of the search results.
     */
   def lookupUser(id: String,
-                 expansions: Seq[Expansions] = Seq.empty[Expansions],
+                 expansions: Seq[UserExpansions] = Seq.empty[UserExpansions],
                  tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
                  userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[UserResponse]] = {
     import restClient._
@@ -146,7 +146,7 @@ trait TwitterUserLookupClient {
     * @return : The representation of the search results.
     */
   def lookupUsersByUsernames(usernames: Seq[String],
-                             expansions: Seq[Expansions] = Seq.empty[Expansions],
+                             expansions: Seq[UserExpansions] = Seq.empty[UserExpansions],
                              tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
                              userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[UsersResponse]] = {
     import restClient._
@@ -195,7 +195,7 @@ trait TwitterUserLookupClient {
     * @return : The representation of the search results.
     */
   def lookupUserByUsername(username: String,
-                           expansions: Seq[Expansions] = Seq.empty[Expansions],
+                           expansions: Seq[UserExpansions] = Seq.empty[UserExpansions],
                            tweetFields: Seq[TweetFields] = Seq.empty[TweetFields],
                            userFields: Seq[UserFields] = Seq.empty[UserFields]): Future[RatedData[UserResponse]] = {
     import restClient._

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UserByUsernameParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UserByUsernameParameters.scala
@@ -1,10 +1,10 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.users.parameters
 
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.UserExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
 import com.danielasfregola.twitter4s.http.marshalling.Parameters
 
-private[twitter4s] final case class UserByUsernameParameters(expansions: Seq[Expansions],
+private[twitter4s] final case class UserByUsernameParameters(expansions: Seq[UserExpansions],
                                                              `tweet.fields`: Seq[TweetFields] = Seq.empty[TweetFields],
                                                              `user.fields`: Seq[UserFields] = Seq.empty[UserFields]) extends Parameters

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UserParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UserParameters.scala
@@ -1,10 +1,10 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.users.parameters
 
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.UserExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
 import com.danielasfregola.twitter4s.http.marshalling.Parameters
 
-private[twitter4s] final case class UserParameters(expansions: Seq[Expansions],
+private[twitter4s] final case class UserParameters(expansions: Seq[UserExpansions],
                                                    `tweet.fields`: Seq[TweetFields] = Seq.empty[TweetFields],
                                                    `user.fields`: Seq[UserFields] = Seq.empty[UserFields]) extends Parameters

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UsersByUsernamesParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UsersByUsernamesParameters.scala
@@ -1,11 +1,11 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.users.parameters
 
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.UserExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
 import com.danielasfregola.twitter4s.http.marshalling.Parameters
 
 private[twitter4s] final case class UsersByUsernamesParameters(usernames: Seq[String],
-                                                               expansions: Seq[Expansions],
+                                                               expansions: Seq[UserExpansions],
                                                                `tweet.fields`: Seq[TweetFields] = Seq.empty[TweetFields],
                                                                `user.fields`: Seq[UserFields] = Seq.empty[UserFields]) extends Parameters

--- a/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UsersParameters.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/parameters/UsersParameters.scala
@@ -1,11 +1,11 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.users.parameters
 
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.Expansions
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.UserExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
 import com.danielasfregola.twitter4s.http.marshalling.Parameters
 
 private[twitter4s] final case class UsersParameters(ids: Seq[String],
-                                                    expansions: Seq[Expansions],
+                                                    expansions: Seq[UserExpansions],
                                                     `tweet.fields`: Seq[TweetFields] = Seq.empty[TweetFields],
                                                     `user.fields`: Seq[UserFields] = Seq.empty[UserFields]) extends Parameters

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTimelinesClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterTimelinesClientSpec.scala
@@ -2,7 +2,7 @@ package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets
 
 import akka.http.scaladsl.model.HttpMethods
 import com.danielasfregola.twitter4s.entities.RatedData
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.{Expansions => TweetExpansions}
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.TweetExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/TwitterUserLookupClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/users/TwitterUserLookupClientSpec.scala
@@ -2,7 +2,7 @@ package com.danielasfregola.twitter4s.http.clients.rest.v2.users
 
 import akka.http.scaladsl.model.HttpMethods
 import com.danielasfregola.twitter4s.entities.RatedData
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.{Expansions => UserExpansions}
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.UserExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields
 import com.danielasfregola.twitter4s.entities.v2.responses.{UserResponse, UsersResponse}

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/utils/V2SpecQueryHelper.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/utils/V2SpecQueryHelper.scala
@@ -1,9 +1,9 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.utils
 
 import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.{Expansions => TweetExpansions}
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.TweetExpansions.TweetExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions
-import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.{Expansions => UserExpansions}
+import com.danielasfregola.twitter4s.entities.v2.enums.expansions.UserExpansions.UserExpansions
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.MediaFields.MediaFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.TweetFields.TweetFields
 import com.danielasfregola.twitter4s.entities.v2.enums.fields.UserFields.UserFields


### PR DESCRIPTION
👋 Another PR here to rename `TweetExpansions.Expansions` and `UserExpansions.Expansions` to match their parent object.

This naming mistake was made earlier on and creates situations where the import needs to be renamed as to not conflict with its counterpart. 