### PR TITLE
Add MediaType enum

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/Media.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/Media.scala
@@ -1,7 +1,9 @@
 package com.danielasfregola.twitter4s.entities.v2
 
+import com.danielasfregola.twitter4s.entities.v2.enums.MediaType.MediaType
+
 final case class Media(media_key: String,
-                       `type`: String,
+                       `type`: MediaType,
                        duration_ms: Option[Int],
                        height: Option[Int],
                        non_public_metrics: Option[MediaNonPublicMetrics],

--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/MediaType.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/MediaType.scala
@@ -1,0 +1,9 @@
+package com.danielasfregola.twitter4s.entities.v2.enums
+
+object MediaType extends Enumeration {
+  type MediaType = Value
+
+  val AnimatedGIF = Value("animated_gif")
+  val Photo = Value("photo")
+  val Video = Value("video")
+}

--- a/src/main/scala/com/danielasfregola/twitter4s/http/serializers/EnumFormats.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/serializers/EnumFormats.scala
@@ -1,6 +1,6 @@
 package com.danielasfregola.twitter4s.http.serializers
 import com.danielasfregola.twitter4s.entities.enums._
-import com.danielasfregola.twitter4s.entities.v2.enums._
+import com.danielasfregola.twitter4s.entities.v2.{enums => v2}
 import org.json4s.Formats
 import org.json4s.ext.EnumNameSerializer
 
@@ -24,8 +24,9 @@ private[twitter4s] object EnumFormats extends FormatsComposer {
       new EnumNameSerializer(TimeZone) +
       new EnumNameSerializer(WidgetType) +
       new EnumNameSerializer(WithFilter) +
-      new EnumNameSerializer(CoordinatesType) +
-      new EnumNameSerializer(ReferencedTweetType) +
-      new EnumNameSerializer(TweetReplySetting) +
-      new EnumNameSerializer(WithheldScope)
+      new EnumNameSerializer(v2.CoordinatesType) +
+      new EnumNameSerializer(v2.ReferencedTweetType) +
+      new EnumNameSerializer(v2.TweetReplySetting) +
+      new EnumNameSerializer(v2.WithheldScope) +
+      new EnumNameSerializer(v2.MediaType)
 }

--- a/src/test/resources/twitter/rest/v2/tweets/tweet.json
+++ b/src/test/resources/twitter/rest/v2/tweets/tweet.json
@@ -183,7 +183,7 @@
       {
         "height": 1280,
         "media_key": "7_8340593532515834174",
-        "type": "video"
+        "type": "photo"
       },
       {
         "preview_image_url": "https://pbs.twimg.com/ext_tw_video_thumb/1422932273641500672/pu/img/kjOa5XKoU_UViWar.jpg",
@@ -224,7 +224,7 @@
         "height": 720,
         "width": 1280,
         "media_key": "3_1422208929984139264",
-        "type": "photo"
+        "type": "animated_gif"
       }
     ],
     "places": [

--- a/src/test/resources/twitter/rest/v2/tweets/tweets.json
+++ b/src/test/resources/twitter/rest/v2/tweets/tweets.json
@@ -191,7 +191,7 @@
       {
         "height": 1280,
         "media_key": "7_8340593532515834174",
-        "type": "video"
+        "type": "photo"
       },
       {
         "preview_image_url": "https://pbs.twimg.com/ext_tw_video_thumb/1422932273641500672/pu/img/kjOa5XKoU_UViWar.jpg",
@@ -232,7 +232,7 @@
         "height": 720,
         "width": 1280,
         "media_key": "3_1422208929984139264",
-        "type": "photo"
+        "type": "animated_gif"
       }
     ],
     "places": [

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/deserialization/fixtures/TweetResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/deserialization/fixtures/TweetResponseFixture.scala
@@ -1,6 +1,6 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.deserialization.fixtures
 
-import com.danielasfregola.twitter4s.entities.v2.enums.{CoordinatesType, ReferencedTweetType, TweetReplySetting}
+import com.danielasfregola.twitter4s.entities.v2.enums._
 import com.danielasfregola.twitter4s.entities.v2.responses.TweetResponse
 import com.danielasfregola.twitter4s.entities.v2._
 import java.time.Instant
@@ -221,7 +221,7 @@ object TweetResponseFixture {
         media = Seq(
           Media(
             media_key = "7_8340593532515834174",
-            `type` = "video",
+            `type` = MediaType.Photo,
             duration_ms = None,
             height = Some(1280),
             non_public_metrics = None,
@@ -234,7 +234,7 @@ object TweetResponseFixture {
           ),
           Media(
             media_key = "7_1422932273641500672",
-            `type` = "video",
+            `type` = MediaType.Video,
             duration_ms = Some(70500),
             height = Some(450),
             non_public_metrics = Some(
@@ -274,7 +274,7 @@ object TweetResponseFixture {
           ),
           Media(
             media_key = "3_1422208929984139264",
-            `type` = "photo",
+            `type` = MediaType.AnimatedGIF,
             duration_ms = None,
             height = Some(720),
             non_public_metrics = None,

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/deserialization/fixtures/TweetsResponseFixture.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/deserialization/fixtures/TweetsResponseFixture.scala
@@ -1,6 +1,6 @@
 package com.danielasfregola.twitter4s.http.clients.rest.v2.tweets.deserialization.fixtures
 
-import com.danielasfregola.twitter4s.entities.v2.enums.{CoordinatesType, ReferencedTweetType, TweetReplySetting}
+import com.danielasfregola.twitter4s.entities.v2.enums._
 import com.danielasfregola.twitter4s.entities.v2.responses.TweetsResponse
 import com.danielasfregola.twitter4s.entities.v2._
 import java.time.Instant
@@ -221,7 +221,7 @@ object TweetsResponseFixture {
         media = Seq(
           Media(
             media_key = "7_8340593532515834174",
-            `type` = "video",
+            `type` = MediaType.Photo,
             duration_ms = None,
             height = Some(1280),
             non_public_metrics = None,
@@ -234,7 +234,7 @@ object TweetsResponseFixture {
           ),
           Media(
             media_key = "7_1422932273641500672",
-            `type` = "video",
+            `type` = MediaType.Video,
             duration_ms = Some(70500),
             height = Some(450),
             non_public_metrics = Some(
@@ -274,7 +274,7 @@ object TweetsResponseFixture {
           ),
           Media(
             media_key = "3_1422208929984139264",
-            `type` = "photo",
+            `type` = MediaType.AnimatedGIF,
             duration_ms = None,
             height = Some(720),
             non_public_metrics = None,


### PR DESCRIPTION
[Media.type documentation](https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/media) states that this field can only be one of `animated_gif`,`photo`, and `video`. So we can better represent this field with an enum. 