### PR TITLE
Apply method for TwitterRestV2Client return V2

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/TwitterRestV2Client.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/TwitterRestV2Client.scala
@@ -33,22 +33,23 @@ trait V2RestClients
 
 object TwitterRestV2Client {
 
-  def apply(): TwitterRestClient = {
+  def apply(): TwitterRestV2Client = {
     val consumerToken = ConsumerToken(key = consumerTokenKey, secret = consumerTokenSecret)
     val accessToken = AccessToken(key = accessTokenKey, secret = accessTokenSecret)
     apply(consumerToken, accessToken)
   }
 
-  def apply(consumerToken: ConsumerToken, accessToken: AccessToken): TwitterRestClient =
-    new TwitterRestClient(consumerToken, accessToken)
+  def apply(consumerToken: ConsumerToken, accessToken: AccessToken): TwitterRestV2Client =
+    new TwitterRestV2Client(consumerToken, accessToken)
 
-  def withActorSystem(system: ActorSystem): TwitterRestClient = {
+  def withActorSystem(system: ActorSystem): TwitterRestV2Client = {
     val consumerToken = ConsumerToken(key = consumerTokenKey, secret = consumerTokenSecret)
     val accessToken = AccessToken(key = accessTokenKey, secret = accessTokenSecret)
     withActorSystem(consumerToken, accessToken)(system)
   }
 
-  def withActorSystem(consumerToken: ConsumerToken, accessToken: AccessToken)(system: ActorSystem): TwitterRestClient =
-    new TwitterRestClient(consumerToken, accessToken)(system)
+  def withActorSystem(consumerToken: ConsumerToken, accessToken: AccessToken)(
+      system: ActorSystem): TwitterRestV2Client =
+    new TwitterRestV2Client(consumerToken, accessToken)(system)
 
 }


### PR DESCRIPTION
A correction for a bad copy job. The `apply` methods for TwitterRestV2Client should return V2 instances.