### PR TITLE
Add "following" TweetReplySetting enum

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/TweetReplySetting.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/entities/v2/enums/TweetReplySetting.scala
@@ -6,4 +6,5 @@ object TweetReplySetting extends Enumeration {
   val Everyone = Value("everyone")
   val MentionedUsers = Value("mentioned_users")
   val Followers = Value("followers")
+  val Following = Value("following")
 }


### PR DESCRIPTION
While not documented on [Twitter's Object Model](https://developer.twitter.com/en/docs/twitter-api/data-dictionary/object-model/tweet), "following" is a new value being returned by `reply_settings`.

[*IDs and names obfuscated*] 
```
        {
            "id": "1445555554710916097",
            "reply_settings": "everyone",
            "text": "@WhereWhereJoeJoes We're so happy to have you as a member of our community 🥰"
        },
        {
            "id": "144555555545356289",
            "reply_settings": "following", <==== New?
            "text": "@mooretyyy We love it 😍"
        },
        {
            "id": "1455555555229575682",
            "reply_settings": "everyone",
            "text": "@cdgelodge @caracaradd Shout out to the mountain for being a sponsor 😂⛰️❤️"
        },
```
