### PR TITLE
Properly encode parentheses

### DIFF
--- a/src/main/scala/com/danielasfregola/twitter4s/http/package.scala
+++ b/src/main/scala/com/danielasfregola/twitter4s/http/package.scala
@@ -9,14 +9,12 @@ package object http {
   implicit class RichString(val value: String) extends AnyVal {
 
     def urlEncoded = {
-      val urlEncodePattern = """\+|\*|%7E|%28|%29""".r
+      val urlEncodePattern = """\+|\*|%7E""".r
       val replacer: Regex.Match => String = m =>
         m.group(0) match {
           case "+"   => "%20"
           case "*"   => "%2A"
           case "%7E" => "~"
-          case "%28" => "("
-          case "%29" => ")"
       }
       val encodedValue = URLEncoder.encode(value, "UTF-8")
       urlEncodePattern.replaceAllIn(encodedValue, replacer)

--- a/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterSearchTweetsClientSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/clients/rest/v2/tweets/TwitterSearchTweetsClientSpec.scala
@@ -27,7 +27,7 @@ class TwitterSearchTweetsClientSpec extends ClientSpec {
           request.method === HttpMethods.GET
           request.uri.endpoint === s"https://api.twitter.com/2/tweets/search/recent"
           V2SpecQueryHelper.extractEncodedQueryKeyValuesPairs(request.uri.rawQueryString.get) === Map(
-            "query" -> "-is%3Aretweet%20has%3Ageo%20(from%3ANWSNHC%20OR%20from%3ANHC_Atlantic%20OR%20from%3ANWSHouston%20OR%20from%3ANWSSanAntonio%20OR%20from%3AUSGS_TexasRain%20OR%20from%3AUSGS_TexasFlood%20OR%20from%3AJeffLindner1)",
+            "query" -> "-is%3Aretweet%20has%3Ageo%20%28from%3ANWSNHC%20OR%20from%3ANHC_Atlantic%20OR%20from%3ANWSHouston%20OR%20from%3ANWSSanAntonio%20OR%20from%3AUSGS_TexasRain%20OR%20from%3AUSGS_TexasFlood%20OR%20from%3AJeffLindner1%29",
             "start_time" -> "2021-08-29T19%3A00%3A00Z",
             "end_time" -> "2021-08-30T19%3A00%3A00Z",
             "max_results" -> "20",
@@ -128,7 +128,7 @@ class TwitterSearchTweetsClientSpec extends ClientSpec {
           request.method === HttpMethods.GET
           request.uri.endpoint === s"https://api.twitter.com/2/tweets/search/all"
           V2SpecQueryHelper.extractEncodedQueryKeyValuesPairs(request.uri.rawQueryString.get) === Map(
-            "query" -> "-is%3Aretweet%20has%3Ageo%20(from%3ANWSNHC%20OR%20from%3ANHC_Atlantic%20OR%20from%3ANWSHouston%20OR%20from%3ANWSSanAntonio%20OR%20from%3AUSGS_TexasRain%20OR%20from%3AUSGS_TexasFlood%20OR%20from%3AJeffLindner1)",
+            "query" -> "-is%3Aretweet%20has%3Ageo%20%28from%3ANWSNHC%20OR%20from%3ANHC_Atlantic%20OR%20from%3ANWSHouston%20OR%20from%3ANWSSanAntonio%20OR%20from%3AUSGS_TexasRain%20OR%20from%3AUSGS_TexasFlood%20OR%20from%3AJeffLindner1%29",
             "start_time" -> "2021-08-29T19%3A00%3A00Z",
             "end_time" -> "2021-08-30T19%3A00%3A00Z",
             "max_results" -> "20",

--- a/src/test/scala/com/danielasfregola/twitter4s/http/packageHttpSpec.scala
+++ b/src/test/scala/com/danielasfregola/twitter4s/http/packageHttpSpec.scala
@@ -11,6 +11,7 @@ class packageHttpSpec extends Specification {
       "An encoded string!".urlEncoded === "An%20encoded%20string%21"
       "Dogs, Cats & Mice".urlEncoded === "Dogs%2C%20Cats%20%26%20Mice"
       "☃".urlEncoded === "%E2%98%83"
+      "()".urlEncoded === "%28%29"
     }
   }
 }


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/DanielaSfregola/twitter4s/pull/411

Twitter expects parentheses to be encoded. We are experiencing tweet failures when the text contains parentheses.

I tested the search scenario this was changed for and Twitter properly decodes the encoded parentheses so this shouldn't cause a regression for the v2 search endpoint

![image](https://user-images.githubusercontent.com/49164937/137745747-28be8dc7-e0fc-446e-8d76-b164db6cc3c0.png)
![image](https://user-images.githubusercontent.com/49164937/137746385-93bec5fe-9f3f-43b2-983e-f2fadcd9fc3e.png)
