### PR TITLE
Use Scaladex badge on ReadMe to show Scala version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 twitter4s
 =========
 
+[![twitter4s Scala version support](https://index.scala-lang.org/danielasfregola/twitter4s/twitter4s/latest-by-scala-version.svg)](https://index.scala-lang.org/danielasfregola/twitter4s/twitter4s)
 [![CircleCI](https://circleci.com/gh/DanielaSfregola/twitter4s/tree/main.svg?style=svg)](https://circleci.com/gh/DanielaSfregola/twitter4s/tree/main) [![codecov.io](http://codecov.io/github/DanielaSfregola/twitter4s/coverage.svg?branch=master)](http://codecov.io/github/DanielaSfregola/twitter4s?branch=master) [![License](http://img.shields.io/:license-Apache%202-red.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt)  [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-brightgreen.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org) [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/twitter4s/Lobby)
 
 An asynchronous non-blocking Scala Twitter Client, implemented using Akka-Http and json4s.


### PR DESCRIPTION
This Scaladex badge summarises which versions of Scala are supported by `twitter4s` (and what the latest `twitter4s` version is for each of those Scala versions), so it provides a bit more information than a Maven badge:

[![twitter4s Scala version support](https://index.scala-lang.org/danielasfregola/twitter4s/twitter4s/latest-by-scala-version.svg)](https://index.scala-lang.org/danielasfregola/twitter4s/twitter4s)

More details on the badge format: scalacenter/scaladex#660